### PR TITLE
Added backward compatibility for Python 3.9

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -1,6 +1,7 @@
 import json
 import random
 from tqdm import tqdm
+from typing import Union
 
 import torch
 import torch.nn.functional as F
@@ -188,7 +189,7 @@ def load_dataset(
         dataset_type: str = "CustomDataset", 
         audio_type: str = "raw", 
         mel_spec_kwargs: dict = dict()
-        ) -> CustomDataset | HFDataset:
+        ) -> Union[CustomDataset, HFDataset]:
     
     print("Loading dataset ...")
 


### PR DESCRIPTION
Changed union type (introduced in Python 3.10) to typing.Union to make the dataset.py script work in Python 3.9.