### PR TITLE
Added -f option to read text from a file.

### DIFF
--- a/inference-cli.py
+++ b/inference-cli.py
@@ -20,6 +20,7 @@ import tomli
 import argparse
 import tqdm
 from pathlib import Path
+import codecs
 
 parser = argparse.ArgumentParser(
     prog="python3 inference-cli.py",
@@ -57,6 +58,12 @@ parser.add_argument(
     help="Text to generate.",
 )
 parser.add_argument(
+    "-f",
+    "--gen_file",
+    type=str,
+    help="File with text to generate. Ignores --text",
+)
+parser.add_argument(
     "-o",
     "--output_dir",
     type=str,
@@ -73,6 +80,9 @@ config = tomli.load(open(args.config, "rb"))
 ref_audio = args.ref_audio if args.ref_audio else config["ref_audio"]
 ref_text = args.ref_text if args.ref_text != "666" else config["ref_text"]
 gen_text = args.gen_text if args.gen_text else config["gen_text"]
+gen_file = args.gen_file if args.gen_file else config["gen_file"]
+if gen_file:
+    gen_text = codecs.open(gen_file, "r", "utf-8").read()
 output_dir = args.output_dir if args.output_dir else config["output_dir"]
 model = args.model if args.model else config["model"]
 remove_silence = args.remove_silence if args.remove_silence else config["remove_silence"]

--- a/inference-cli.toml
+++ b/inference-cli.toml
@@ -4,5 +4,7 @@ ref_audio = "tests/ref_audio/test_en_1_ref_short.wav"
 # If an empty "", transcribes the reference audio automatically.
 ref_text = "Some call me nature, others call me mother nature."
 gen_text = "I don't really care what you call me. I've been a silent spectator, watching species evolve, empires rise and fall. But always remember, I am mighty and enduring. Respect me and I'll nurture you; ignore me and you shall face the consequences."
+# File with text to generate. Ignores the text above.
+gen_file = ""
 remove_silence = true
 output_dir = "tests"


### PR DESCRIPTION
Using -f option in cli, you can specify a file to read text to generate.
When both -t and -f are specified, -t is ignored.