### PR TITLE
Split dependencies, late-import bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Install other packages:
 pip install -r requirements.txt
 ```
 
+You can also install a smaller set of packages, e.g. to only run inference in English:
+
+```bash
+pip install -r requirements-infer.txt -r requirements-en.txt
+```
+
+
 ## Prepare Dataset
 
 Example data processing scripts for Emilia and Wenetspeech4TTS, and you may tailor your own one along with a Dataset class in `model/dataset.py`.

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -17,7 +17,6 @@ from model.utils import (
     save_spectrogram,
 )
 from transformers import pipeline
-import librosa
 import click
 import soundfile as sf
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,7 +1,12 @@
+import warnings
+
 from model.cfm import CFM
 
 from model.backbones.unett import UNetT
 from model.backbones.dit import DiT
 from model.backbones.mmdit import MMDiT
 
-from model.trainer import Trainer
+try:
+    from model.trainer import Trainer
+except Exception as e:
+    warnings.warn(f"Unable to import trainer module: {e}")

--- a/requirements-en.txt
+++ b/requirements-en.txt
@@ -1,0 +1,1 @@
+faster_whisper

--- a/requirements-infer.txt
+++ b/requirements-infer.txt
@@ -1,0 +1,12 @@
+cached_path
+einops>=0.8.0
+einx>=0.3.0
+ema_pytorch>=0.5.2
+gradio
+matplotlib
+numpy<=1.26.4
+soundfile
+torchdiffeq
+transformers
+vocos
+x-transformers>=1.31.14

--- a/requirements-train.txt
+++ b/requirements-train.txt
@@ -1,0 +1,9 @@
+accelerate>=0.33.0
+click
+datasets
+numpy<=1.26.4
+pydub
+safetensors
+tomli
+tqdm>=4.65.0
+wandb

--- a/requirements-zh.txt
+++ b/requirements-zh.txt
@@ -1,0 +1,6 @@
+zhconv
+zhon
+pypinyin
+jieba
+jiwer
+funasr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,6 @@
-accelerate>=0.33.0
-cached_path
-click
-datasets
-einops>=0.8.0
-einx>=0.3.0
-ema_pytorch>=0.5.2
-faster_whisper
-funasr
-gradio
-jieba
-jiwer
-matplotlib
-numpy<=1.26.4
-pydub
-pypinyin
-safetensors
-soundfile
 # torch>=2.0
 # torchaudio>=2.3.0
-torchdiffeq
-tqdm>=4.65.0
-transformers
-vocos
-wandb
-x_transformers>=1.31.14
-zhconv
-zhon
-tomli
+-r requirements-en.txt
+-r requirements-infer.txt
+-r requirements-train.txt
+-r requirements-zh.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ funasr
 gradio
 jieba
 jiwer
-librosa
 matplotlib
 numpy<=1.26.4
 pydub


### PR DESCRIPTION
This PR allows installing this repository without having to install as many dependencies.

Namely, doing `pip install -r requirements-infer.txt -r requirements-en.txt` will be enough to install inference dependencies for English. (I tried this out with a fresh venv on my laptop.)

Trying to do `zh` inference, or training, with this set of requirements installed, will fail with an `ImportError` sooner or later.

`pip install -r requirements.txt` should still work as before.

Thank you for your work, the results are impressive!