### PR TITLE
allow multiple audio files for finetune UI

### DIFF
--- a/finetune_gradio.py
+++ b/finetune_gradio.py
@@ -339,7 +339,7 @@ def transcribe(file_audio,language="english"):
     )["text"].strip()
     return text_transcribe
 
-def transcribe_all(name_project,audio_file,language,user=False,progress=gr.Progress()):
+def transcribe_all(name_project,audio_files,language,user=False,progress=gr.Progress()):
     name_project+="_pinyin"
     path_project= os.path.join(path_data,name_project)
     path_dataset = os.path.join(path_project,"dataset")
@@ -357,7 +357,7 @@ def transcribe_all(name_project,audio_file,language,user=False,progress=gr.Progr
     if user:
        file_audios = [file for format in ('*.wav', '*.ogg', '*.opus', '*.mp3', '*.flac') for file in glob(os.path.join(path_dataset, format))]
     else:
-       file_audios = [audio_file]
+       file_audios = audio_files
 
     print([file_audios])   
 
@@ -580,7 +580,7 @@ with gr.Blocks() as app:
          ...
      ```""",visible=False)
 
-              audio_speaker = gr.Audio(label="voice",type="filepath")
+              audio_speaker = gr.File(label="voice",type="filepath",file_count="multiple")
               txt_lang = gr.Text(label="Language",value="english")
               bt_transcribe=bt_create=gr.Button("transcribe")
               txt_info_transcribe=gr.Text(label="info",value="")


### PR DESCRIPTION
The existing finetune UI only lets you upload one audio clip file because it uses a gradio audio component (which only allows one file).

I switched it to use gradio file component with `file_count="multiple"` so we can upload multiple audio files and transcribe them all automatically.

Here's what it looks like:

![abcdefga](https://github.com/user-attachments/assets/ae16a4d3-2ca3-49b4-95d3-26ccf15937a6)
