### PR TITLE
[bug fix] fix ValueError in HF demo

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -791,4 +791,4 @@ if __name__ == "__main__":
     if not USING_SPACES:
         main()
     else:
-        app.queue().launch()
+        app.queue().launch(share=True)


### PR DESCRIPTION
added `share=True` to fix this error in the [Hugging Face space](https://huggingface.co/spaces/mrfakename/E2-F5-TTS): 
```
Traceback (most recent call last):
  File "/home/user/app/app.py", line 794, in <module>
    app.queue().launch()
  File "/usr/local/lib/python3.10/site-packages/spaces/zero/gradio.py", line 144, in launch
    return gr.Blocks.launch(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/gradio/blocks.py", line 2581, in launch
    raise ValueError(
ValueError: When localhost is not accessible, a shareable link must be created. Please set share=True or check your proxy settings to allow access to localhost.
```
