### PR TITLE
User-friendly wandb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ An initial guidance on Finetuning [#57](https://github.com/SWivid/F5-TTS/discuss
 
 Gradio UI finetuning with `finetune_gradio.py` see [#143](https://github.com/SWivid/F5-TTS/discussions/143).
 
+## Wandb Logging
+
+By default, the training script does NOT use logging (assuming you didn't manually log in using `wandb login`).
+
+To turn on wandb logging, you can either:
+
+1. Manually login with `wandb login`: Learn more [here](https://docs.wandb.ai/ref/cli/wandb-login)
+2. Automatically login programmatically by setting an environment variable: Get an API KEY at https://wandb.ai/site/ and set the environment variable as follows:
+
+On Mac & Linux:
+
+```
+export WANDB_API_KEY=<YOUR WANDB API KEY>
+```
+
+On Windows:
+
+```
+set WANDB_API_KEY=<YOUR WANDB API KEY>
+```
+
 ## Inference
 
 The pretrained model checkpoints can be reached at [🤗 Hugging Face](https://huggingface.co/SWivid/F5-TTS) and [🤖 Model Scope](https://www.modelscope.cn/models/SWivid/F5-TTS_Emilia-ZH-EN), or automatically downloaded with `inference-cli` and `gradio_app`.

--- a/model/trainer.py
+++ b/model/trainer.py
@@ -50,31 +50,35 @@ class Trainer:
         
         ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters = True)
 
+        logger = "wandb" if wandb.api.api_key else None
+        print(f"Using logger: {logger}")
+
         self.accelerator = Accelerator(
-            log_with = "wandb",
+            log_with = logger,
             kwargs_handlers = [ddp_kwargs],
             gradient_accumulation_steps = grad_accumulation_steps,
             **accelerate_kwargs
         )
-        
-        if exists(wandb_resume_id):
-            init_kwargs={"wandb": {"resume": "allow", "name": wandb_run_name, 'id': wandb_resume_id}}
-        else:
-            init_kwargs={"wandb": {"resume": "allow", "name": wandb_run_name}}
-        self.accelerator.init_trackers(
-            project_name = wandb_project, 
-            init_kwargs=init_kwargs,
-            config={"epochs": epochs,
-                    "learning_rate": learning_rate,
-                    "num_warmup_updates": num_warmup_updates, 
-                    "batch_size": batch_size,
-                    "batch_size_type": batch_size_type,
-                    "max_samples": max_samples,
-                    "grad_accumulation_steps": grad_accumulation_steps,
-                    "max_grad_norm": max_grad_norm,
-                    "gpus": self.accelerator.num_processes,
-                    "noise_scheduler": noise_scheduler}
-            )
+
+        if logger == "wandb":
+            if exists(wandb_resume_id):
+                init_kwargs={"wandb": {"resume": "allow", "name": wandb_run_name, 'id': wandb_resume_id}}
+            else:
+                init_kwargs={"wandb": {"resume": "allow", "name": wandb_run_name}}
+            self.accelerator.init_trackers(
+                project_name = wandb_project,
+                init_kwargs=init_kwargs,
+                config={"epochs": epochs,
+                        "learning_rate": learning_rate,
+                        "num_warmup_updates": num_warmup_updates,
+                        "batch_size": batch_size,
+                        "batch_size_type": batch_size_type,
+                        "max_samples": max_samples,
+                        "grad_accumulation_steps": grad_accumulation_steps,
+                        "max_grad_norm": max_grad_norm,
+                        "gpus": self.accelerator.num_processes,
+                        "noise_scheduler": noise_scheduler}
+                )
 
         self.model = model
 


### PR DESCRIPTION
Two things to make the wandb integration more user friendly.

# 1. Document wandb login

Currently the training script cannot be run unless you are already logged into wandb using something like `wandb login`. This means you have to run the login manually, and makes this not easily deployable (both locally and to cloud services).

Fortunately, if you have `WANDB_API_KEY` set, you do NOT need to manually login to wandb. This becomes especially important when we're trying to run this through the gradio UI, since we can no longer assume the user is running things manually from the terminal. There needs to be a way for the gradio app to launch without first having to run `wandb login` in the terminal. This PR documents this feature, so to use the logging (for both the cli and the gradio app), one just needs to set the `WANDB_API_KEY` environment variable.

# 2. Provide an option to NOT use wandb

The existing code requires you to use wandb, and the training won't work if you don't sign up for a wandb account. I think the default should let people train without this requirement. So the update in the `trainer.py` checks if the user is already logged into wandb (either through `wandb login` manually, or through the `WANDB_API_KEY` environment variable), and if NOT logged in, do not attempt to log and do not require the user to sign up to wandb.

Note that this does not change the existing behavior who already got it to work by manually logging into wandb before running the training, since all it checks is if it's logged in, and if not, just don't use the logging (previously it used to just fail if not logged in).

Have tested and verified it works for both cases (logged in and not logged in).