### PR TITLE
Update pyproject.toml - Specify required Gradio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "click",
     "datasets",
     "ema_pytorch>=0.5.2",
-    "gradio",
+    "gradio>=3.45.2",
     "jieba",
     "librosa",
     "matplotlib",


### PR DESCRIPTION
Specify required Gradio version to avoid errors with the Progress object. Earlier versions will give the error:
```
File ".../F5-TTS/model/utils_infer.py", line 268, in infer_batch_process
    text_list = [ref_text + gen_text]
TypeError: can only concatenate str (not "Progress") to str
```
I am pretty sure the PR which changed this behavior is https://github.com/gradio-app/gradio/pull/5693, which was merged for 3.45.2. Certainly, you get the above error with 3.36.1 and it works with 3.45.2.