### PR TITLE
Update README: must be lowercase docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pip install -e .
 docker build -t f5tts:v1 .
 
 # Or pull from GitHub Container Registry
-docker pull ghcr.io/SWivid/F5-TTS:main
+docker pull ghcr.io/swivid/f5-tts:main
 ```
 
 


### PR DESCRIPTION
## Corrected version

```bash
# Build from Dockerfile
docker build -t f5tts:v1 .

# Or pull from GitHub Container Registry
docker pull ghcr.io/swivid/f5-tts:main
```

## Error on docker pull

```bash
# Build from Dockerfile
docker build -t f5tts:v1 .

# Or pull from GitHub Container Registry
docker pull ghcr.io/SWivid/F5-TTS:main

[+] Building 0.1s (1/1) FINISHED                                                                                                                                           docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 2B                                                                                                                                                    0.0s
ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
invalid reference format: repository name (SWivid/F5-TTS) must be lowercase
```