### PR TITLE
Fix Potential Bug in TextEmbedding when text_len exceeds seq_len

### DIFF
--- a/src/f5_tts/model/backbones/dit.py
+++ b/src/f5_tts/model/backbones/dit.py
@@ -48,7 +48,7 @@ class TextEmbedding(nn.Module):
         text = text + 1  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
         text = text[:, :seq_len]  # curtail if character tokens are more than the mel spec tokens
         batch, text_len = text.shape[0], text.shape[1]
-        text = F.pad(text, (0, seq_len - text_len), value=0)
+        text = F.pad(text, (0, max(0, seq_len - text_len)), value=0)
 
         if drop_text:  # cfg for text
             text = torch.zeros_like(text)


### PR DESCRIPTION
I found a potential bug with TextEmbedding in [dit.py](https://github.com/SWivid/F5-TTS/blob/dee0420b59819cea85917d0bb15521aa96bf3f5b/src/f5_tts/model/backbones/dit.py#L51)

For example if
```
text_len = 1497
seq_len = 758 
```
After padding, the text shape becomes 758*2 - 1497 = 19, text shape (batch, 19, 512), resulting in
`RuntimeError: The size of tensor a (19) must match the size of tensor b (758) at non-singleton dimension 1."
`
in line [64](https://github.com/SWivid/F5-TTS/blob/dee0420b59819cea85917d0bb15521aa96bf3f5b/src/f5_tts/model/backbones/dit.py#L64C13-L64C41)
`text = text + text_pos_embed
`


Update: Oops, sorry! I used the old code and didn't realize that the updated code had already fixed it