### PR TITLE
Add root_path argument to support reverse proxies

### DIFF
--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -831,7 +831,7 @@ If you're having issues, try converting your reference audio to WAV or MP3, clip
     help="Share the app via Gradio share link",
 )
 @click.option("--api", "-a", default=True, is_flag=True, help="Allow API access")
-@click.option("--root_path", "-r", default=None, type=str, help="The root path of the gradio application if it's not served from the root (\"/\") of the domain. Set this value if the application is behind a reverse proxy that forwards the request to a subdirectory of the domain.")
+@click.option("--root_path", "-r", default=None, type=str, help="The root path (or "mount point") of the application, if it's not served from the root (\"/\") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application, e.g. set \"/myapp\" or full URL for application served at \"https://example.com/myapp\".")
 def main(port, host, share, api, root_path):
     global app
     print("Starting app...")

--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -831,7 +831,13 @@ If you're having issues, try converting your reference audio to WAV or MP3, clip
     help="Share the app via Gradio share link",
 )
 @click.option("--api", "-a", default=True, is_flag=True, help="Allow API access")
-@click.option("--root_path", "-r", default=None, type=str, help="The root path (or \"mount point\") of the application, if it's not served from the root (\"/\") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application, e.g. set \"/myapp\" or full URL for application served at \"https://example.com/myapp\".")
+@click.option(
+    "--root_path",
+    "-r",
+    default=None,
+    type=str,
+    help='The root path (or "mount point") of the application, if it\'s not served from the root ("/") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application, e.g. set "/myapp" or full URL for application served at "https://example.com/myapp".',
+)
 def main(port, host, share, api, root_path):
     global app
     print("Starting app...")

--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -831,7 +831,7 @@ If you're having issues, try converting your reference audio to WAV or MP3, clip
     help="Share the app via Gradio share link",
 )
 @click.option("--api", "-a", default=True, is_flag=True, help="Allow API access")
-@click.option("--root_path", "-r", default=None, type=str, help="The root path (or "mount point") of the application, if it's not served from the root (\"/\") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application, e.g. set \"/myapp\" or full URL for application served at \"https://example.com/myapp\".")
+@click.option("--root_path", "-r", default=None, type=str, help="The root path (or \"mount point\") of the application, if it's not served from the root (\"/\") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application, e.g. set \"/myapp\" or full URL for application served at \"https://example.com/myapp\".")
 def main(port, host, share, api, root_path):
     global app
     print("Starting app...")

--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -843,6 +843,7 @@ def main(port, host, share, api, root_path):
     print("Starting app...")
     app.queue(api_open=api).launch(server_name=host, server_port=port, share=share, show_api=api, root_path=root_path)
 
+
 if __name__ == "__main__":
     if not USING_SPACES:
         main()

--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -831,11 +831,11 @@ If you're having issues, try converting your reference audio to WAV or MP3, clip
     help="Share the app via Gradio share link",
 )
 @click.option("--api", "-a", default=True, is_flag=True, help="Allow API access")
-def main(port, host, share, api):
+@click.option("--root_path", "-r", default=None, type=str, help="The root path of the gradio application if it's not served from the root (\"/\") of the domain. Set this value if the application is behind a reverse proxy that forwards the request to a subdirectory of the domain.")
+def main(port, host, share, api, root_path):
     global app
     print("Starting app...")
-    app.queue(api_open=api).launch(server_name=host, server_port=port, share=share, show_api=api)
-
+    app.queue(api_open=api).launch(server_name=host, server_port=port, share=share, show_api=api, root_path=root_path)
 
 if __name__ == "__main__":
     if not USING_SPACES:


### PR DESCRIPTION
Enables providing a reverse proxy subdirectory to gradio. Without this, trying to host the f5 gradio service behind the non-root path of a domain results in incorrect resource/asset paths.