### PR TITLE
Flag support for socket.py

### DIFF
--- a/src/f5_tts/infer/README.md
+++ b/src/f5_tts/infer/README.md
@@ -123,7 +123,7 @@ python src/f5_tts/infer/speech_edit.py
 
 To communicate with socket server you need to run 
 ```bash
-python src/f5_tts/socket_server.py
+python src/f5_tts/socket_server.py --checkpoint /path/to/ckpt.pt --vocab /path/to/vocab.txt --ref-audio /path/to/ref/audio.wav --ref-text "Some reference text"
 ```
 
 <details>

--- a/src/f5_tts/socket_server.py
+++ b/src/f5_tts/socket_server.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import socket
 import struct
 import torch
@@ -170,6 +169,20 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
+        "--host",
+        dest="host",
+        help="Server address",
+        default="0.0.0.0",
+    )
+
+    parser.add_argument(
+        "--port",
+        dest="port",
+        help="Server port",
+        default=9998,
+    )
+
+    parser.add_argument(
         "--checkpoint",
         dest="ckpt_file",
         help="Checkpoint file to load",
@@ -210,6 +223,6 @@ if __name__ == "__main__":
         )
 
         # Start the server
-        start_server("0.0.0.0", 9998, processor)
+        start_server(args.host, args.port, processor)
     except KeyboardInterrupt:
         gc.collect()

--- a/src/f5_tts/socket_server.py
+++ b/src/f5_tts/socket_server.py
@@ -31,18 +31,12 @@ class TTSStreamingProcessor:
         device=None,
         dtype=torch.float32,
     ):
-        self.device = (
-            "cuda"
-            if torch.cuda.is_available()
-            else "mps" if torch.backends.mps.is_available() else "cpu"
-        )
+        self.device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
         # Load the model using the provided checkpoint and vocab files
         self.model = load_model(
             model_cls=DiT,
-            model_cfg=dict(
-                dim=1024, depth=22, heads=16, ff_mult=2, text_dim=512, conv_layers=4
-            ),
+            model_cfg=dict(dim=1024, depth=22, heads=16, ff_mult=2, text_dim=512, conv_layers=4),
             ckpt_path=ckpt_file,
             mel_spec_type="vocos",  # or "bigvgan" depending on vocoder
             vocab_file=vocab_file,


### PR DESCRIPTION
Hello, I am developing a Home assistant Addon and Integration to run the socket server and connect to it so decided to suggest this change.

Would be a good quality of life change to allow users to specify flags and override some of the default values such as:

- Server address
- Server port
- Checkpoint file
- Vocab file
- Reference audio
- Reference text

After I develop the Addon and Integration I will add it to the readme as well for anyone interested to run this in Home Assistant. This will require some additional changes to add a middleware wrapper for the Wyoming protocol.

This is the integration PR: https://github.com/home-assistant/core/pull/131936. It is closed while i work on the Addon and set up everything.

Note: For the formatting a ran ruff and it passes, so assuming the structure is ok ?