### PR TITLE
utils_infer.py: Fix pathing issue that prevents importing BigVGAN

### DIFF
--- a/src/f5_tts/infer/utils_infer.py
+++ b/src/f5_tts/infer/utils_infer.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 os.environ["PYTOCH_ENABLE_MPS_FALLBACK"] = "1"  # for MPS device compatibility
-sys.path.append(f"../../{os.path.dirname(os.path.abspath(__file__))}/third_party/BigVGAN/")
+sys.path.append(f"{os.path.dirname(os.path.abspath(__file__))}/../../third_party/BigVGAN/")
 
 import hashlib
 import re


### PR DESCRIPTION
Upwards directory traversal goes after getting the base path.

Tested on Linux, using F5-TTS and BigVGAN. Audio is generated.