### PR TITLE
Bug Fix: Parsing Argument --finetune always True

### DIFF
--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -47,7 +47,7 @@ def parse_args():
     parser.add_argument("--num_warmup_updates", type=int, default=300, help="Warmup steps")
     parser.add_argument("--save_per_updates", type=int, default=10000, help="Save checkpoint every X steps")
     parser.add_argument("--last_per_steps", type=int, default=50000, help="Save last checkpoint every X steps")
-    parser.add_argument("--finetune", type=bool, default=True, help="Use Finetune")
+    parser.add_argument('--finetune', action='store_true', default=False, help="Use Finetune")
     parser.add_argument("--pretrain", type=str, default=None, help="the path to the checkpoint")
     parser.add_argument(
         "--tokenizer", type=str, default="pinyin", choices=["pinyin", "char", "custom"], help="Tokenizer type"

--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -60,14 +60,14 @@ def parse_args():
     )
     parser.add_argument(
         "--log_samples",
-        type=bool,
+        action="store_true",
         default=False,
         help="Log inferenced samples per ckpt save steps",
     )
     parser.add_argument("--logger", type=str, default=None, choices=["wandb", "tensorboard"], help="logger")
     parser.add_argument(
         "--bnb_optimizer",
-        type=bool,
+        action="store_true",
         default=False,
         help="Use 8-bit Adam optimizer from bitsandbytes",
     )

--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -47,7 +47,7 @@ def parse_args():
     parser.add_argument("--num_warmup_updates", type=int, default=300, help="Warmup steps")
     parser.add_argument("--save_per_updates", type=int, default=10000, help="Save checkpoint every X steps")
     parser.add_argument("--last_per_steps", type=int, default=50000, help="Save last checkpoint every X steps")
-    parser.add_argument("--finetune", action="store_true", default=False, help="Use Finetune")
+    parser.add_argument("--finetune", action="store_true", help="Use Finetune")
     parser.add_argument("--pretrain", type=str, default=None, help="the path to the checkpoint")
     parser.add_argument(
         "--tokenizer", type=str, default="pinyin", choices=["pinyin", "char", "custom"], help="Tokenizer type"
@@ -61,14 +61,12 @@ def parse_args():
     parser.add_argument(
         "--log_samples",
         action="store_true",
-        default=False,
         help="Log inferenced samples per ckpt save steps",
     )
     parser.add_argument("--logger", type=str, default=None, choices=["wandb", "tensorboard"], help="logger")
     parser.add_argument(
         "--bnb_optimizer",
         action="store_true",
-        default=False,
         help="Use 8-bit Adam optimizer from bitsandbytes",
     )
 

--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -47,7 +47,7 @@ def parse_args():
     parser.add_argument("--num_warmup_updates", type=int, default=300, help="Warmup steps")
     parser.add_argument("--save_per_updates", type=int, default=10000, help="Save checkpoint every X steps")
     parser.add_argument("--last_per_steps", type=int, default=50000, help="Save last checkpoint every X steps")
-    parser.add_argument('--finetune', action='store_true', default=False, help="Use Finetune")
+    parser.add_argument("--finetune", action="store_true", default=False, help="Use Finetune")
     parser.add_argument("--pretrain", type=str, default=None, help="the path to the checkpoint")
     parser.add_argument(
         "--tokenizer", type=str, default="pinyin", choices=["pinyin", "char", "custom"], help="Tokenizer type"

--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -453,7 +453,7 @@ def start_training(
     )
 
     if finetune:
-        cmd += f" --finetune"
+        cmd += " --finetune"
 
     if file_checkpoint_train != "":
         cmd += f" --pretrain {file_checkpoint_train}"

--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -452,7 +452,8 @@ def start_training(
         f"--dataset_name {dataset_name}"
     )
 
-    cmd += f" --finetune {finetune}"
+    if finetune:
+        cmd += f" --finetune {finetune}"
 
     if file_checkpoint_train != "":
         cmd += f" --pretrain {file_checkpoint_train}"

--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -453,7 +453,7 @@ def start_training(
     )
 
     if finetune:
-        cmd += f" --finetune {finetune}"
+        cmd += f" --finetune"
 
     if file_checkpoint_train != "":
         cmd += f" --pretrain {file_checkpoint_train}"
@@ -461,12 +461,12 @@ def start_training(
     if tokenizer_file != "":
         cmd += f" --tokenizer_path {tokenizer_file}"
 
-    cmd += f" --tokenizer {tokenizer_type} "
+    cmd += f" --tokenizer {tokenizer_type}"
 
-    cmd += f" --log_samples True --logger {logger} "
+    cmd += f" --log_samples --logger {logger}"
 
     if ch_8bit_adam:
-        cmd += " --bnb_optimizer True "
+        cmd += " --bnb_optimizer"
 
     print("run command : \n" + cmd + "\n")
 


### PR DESCRIPTION
I use f5-tts_finetune-gradio and found out that the finetune checkbox will always send finetune=true to the argument, eventhought the checkbox are off.

After some investigation turns out using type=bool on ArgumentParser always return true because in python:
`bool("False")` are `True`.