### PR TITLE
Exclude pretrained models from the checkpoint rotation logic

### DIFF
--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -111,7 +111,8 @@ def main():
         if not os.path.isdir(checkpoint_path):
             os.makedirs(checkpoint_path, exist_ok=True)
 
-        file_checkpoint = os.path.join(checkpoint_path, os.path.basename(ckpt_path))
+        # Change: Add 'pretrained_' prefix to copied model
+        file_checkpoint = os.path.join(checkpoint_path, "pretrained_" + os.path.basename(ckpt_path))
         if not os.path.isfile(file_checkpoint):
             shutil.copy2(ckpt_path, file_checkpoint)
             print("copy checkpoint for finetune")

--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -1068,7 +1068,9 @@ def vocab_extend(project_name, symbols, model_type):
     dataset_name = name_project.replace("_pinyin", "").replace("_char", "")
     new_ckpt_path = os.path.join(path_project_ckpts, dataset_name)
     os.makedirs(new_ckpt_path, exist_ok=True)
-    new_ckpt_file = os.path.join(new_ckpt_path, "model_1200000.pt")
+
+    # Add pretrained_ prefix to model when copying for consistency with finetune_cli.py
+    new_ckpt_file = os.path.join(new_ckpt_path, "pretrained_model_1200000.pt")
 
     size = expand_model_embeddings(ckpt_path, new_ckpt_file, num_new_tokens=vocab_size_new)
 


### PR DESCRIPTION
There was an issue due to the pretrained models having the same name as the checkpoints saved during model training. Suppose `keep_last_n_checkpoints` was set to 5 since the pretrained model was also included in this count, only 4 training checkpoints + 1 pretrained model checkpoint were actually kept. Additionally, in long enough training sessions, there was a risk of the pretrained model being deleted. These changes address this issue. 

If there are any modifications I might have overlooked, it would be great if you could review them and provide feedback.