### PR TITLE
Docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  f5-tts:
+    image: ghcr.io/swivid/f5-tts:main
+    ports:
+      - "7860:7860"
+    environment:
+      GRADIO_SERVER_PORT: 7860
+    entrypoint: ["f5-tts_infer-gradio", "--port", "7860", "--host", "0.0.0.0"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+volumes:
+  f5-tts:
+    driver: local


### PR DESCRIPTION
Adds a simple docker compose file for Gradio inference to help people get the project up and running quickly with just: `docker compose up`

Note: the file is written for CUDA support with [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) only.