### PR TITLE
Add link back to GitHub repo, clarify local demo

### DIFF
--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -746,10 +746,10 @@ Have a conversation with an AI using your reference voice!
 
 with gr.Blocks() as app:
     gr.Markdown(
-        """
+        f"""
 # E2/F5 TTS
 
-This is a local web UI for F5 TTS with advanced batch processing support. This app supports the following TTS models:
+This is {"a local web UI for [F5 TTS](https://github.com/SWivid/F5-TTS)" if not USING_SPACES else "an online demo for [F5-TTS](https://github.com/SWivid/F5-TTS)"} with advanced batch processing support. This app supports the following TTS models:
 
 * [F5-TTS](https://arxiv.org/abs/2410.06885) (A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching)
 * [E2 TTS](https://arxiv.org/abs/2406.18009) (Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS)


### PR DESCRIPTION
Hi,
This PR adds a link back to the Gradio app and clarifies that the online demo is not running locally.
Thanks!