### PR TITLE
fix: typo in MPS PyTorch env variable

### DIFF
--- a/src/f5_tts/infer/speech_edit.py
+++ b/src/f5_tts/infer/speech_edit.py
@@ -1,6 +1,6 @@
 import os
 
-os.environ["PYTOCH_ENABLE_MPS_FALLBACK"] = "1"  # for MPS device compatibility
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"  # for MPS device compatibility
 
 import torch
 import torch.nn.functional as F

--- a/src/f5_tts/infer/utils_infer.py
+++ b/src/f5_tts/infer/utils_infer.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-os.environ["PYTOCH_ENABLE_MPS_FALLBACK"] = "1"  # for MPS device compatibility
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"  # for MPS device compatibility
 sys.path.append(f"{os.path.dirname(os.path.abspath(__file__))}/../../third_party/BigVGAN/")
 
 import hashlib


### PR DESCRIPTION
# Relates to
cb8ce3306d70dfbee0e7d2423cc7f06e1c2b9c60
#477 
#475

# Risks
Low - This is a simple typo fix in an environment variable name that affects MPS device compatibility.

# Background

## What does this PR do?
Fixes a typo in the environment variable name `PYTOCH_ENABLE_MPS_FALLBACK` to `PYTORCH_ENABLE_MPS_FALLBACK` in two files:
- src/f5_tts/infer/speech_edit.py
- src/f5_tts/infer/utils_infer.py

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
Possibly:
```py
# APPLE SILICON: install the latest stable pytorch, e.g.
pip3 install torch torchvision torchaudio
```

# Testing

## Where should a reviewer start?
Check the environment variable name correction in both files:
1. src/f5_tts/infer/speech_edit.py
2. src/f5_tts/infer/utils_infer.py

## Detailed testing steps
1. Test the code on an MPS-enabled device (e.g., Apple Silicon Mac) to verify that MPS fallback works correctly
2. Verify that the environment variable is properly recognized by PyTorch

The corrected environment variable name should enable proper MPS device fallback functionality on supported hardware.