### PR TITLE
feat: Add autolaunch option to Gradio interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ f5-tts_infer-gradio --port 7860 --host 0.0.0.0
 
 # Launch a share link
 f5-tts_infer-gradio --share
+
+# Automatically open in default web browser
+f5-tts_infer-gradio --autolaunch
 ```
 
 <details>

--- a/src/f5_tts/infer/infer_gradio.py
+++ b/src/f5_tts/infer/infer_gradio.py
@@ -875,10 +875,19 @@ If you're having issues, try converting your reference audio to WAV or MP3, clip
     type=str,
     help='The root path (or "mount point") of the application, if it\'s not served from the root ("/") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application, e.g. set "/myapp" or full URL for application served at "https://example.com/myapp".',
 )
-def main(port, host, share, api, root_path):
+@click.option(
+    "--autolaunch",
+    "-l",
+    is_flag=True,
+    default=False,
+    help="Automatically launch the interface in the default web browser",
+)
+def main(port, host, share, api, root_path, autolaunch):
     global app
     print("Starting app...")
-    app.queue(api_open=api).launch(server_name=host, server_port=port, share=share, show_api=api, root_path=root_path)
+    app.queue(api_open=api).launch(
+        server_name=host, server_port=port, share=share, show_api=api, root_path=root_path, inbrowser=autolaunch
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Relates to
N/A

# Risks
Low - This is a simple addition of a command line flag for user convenience with no changes to core functionality.

# Background

## What does this PR do?
Adds an `--autolaunch` / `-l` command line flag to automatically open the web interface in the default browser when starting the application.

## What kind of change is this?
Features (non-breaking change which adds functionality)
- Adds a new optional command line parameter
- Maintains backward compatibility with existing behavior

# Documentation changes needed?
I have updated the documentation accordingly.

# Testing

## Where should a reviewer start?
1. Review the changes in `src/f5_tts/infer/infer_gradio.py`
2. Test the new `--autolaunch` / `-l` flag functionality

## Detailed testing steps
1. Run the application without the flag to verify default behavior remains unchanged
2. Run the application with `--autolaunch` or `-l` flag and verify:
   - Application starts normally
   - Web interface automatically opens in default browser
3. Verify other command line parameters still work in combination with the new flag

The changes are straightforward and primarily involve:
- Adding a new click option for autolaunch
- Passing the autolaunch parameter to gradio's launch method as `inbrowser`
