### PR TITLE
Escaping spaces in finetune_gradio accelerator launch path

### DIFF
--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -432,7 +432,7 @@ def start_training(
         fp16 = ""
 
     cmd = (
-        f"accelerate launch {fp16} {file_train} --exp_name {exp_name}"
+        f"accelerate launch {fp16} \"{file_train}\" --exp_name {exp_name}"
         f" --learning_rate {learning_rate}"
         f" --batch_size_per_gpu {batch_size_per_gpu}"
         f" --batch_size_type {batch_size_type}"


### PR DESCRIPTION
I had issues starting the training process, due to the path to my F5-TTS repository containing spaces, that were not escaped. Simply adding double quotes around the path solves the issue.