### PR TITLE
Improves documentation around docker usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,9 @@ RUN git clone https://github.com/SWivid/F5-TTS.git \
 
 ENV SHELL=/bin/bash
 
+# models are downloaded into this folder, so user should mount it
+VOLUME /root/.cache/huggingface/hub/
+# port the GUI is exposed on by default, if it is run
+EXPOSE 7860
+
 WORKDIR /workspace/F5-TTS

--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ conda activate f5-tts
 # Build from Dockerfile
 docker build -t f5tts:v1 .
 
-# Or pull from GitHub Container Registry
-docker pull ghcr.io/swivid/f5-tts:main
+# Run from GitHub Container Registry
+docker container run --rm -it --gpus=all --mount 'type=volume,source=f5-tts,target=/root/.cache/huggingface/hub/' -p 7860:7860 ghcr.io/swivid/f5-tts:main
+
+# Quickstart if you want to just run the web interface (not CLI)
+docker container run --rm -it --gpus=all --mount 'type=volume,source=f5-tts,target=/root/.cache/huggingface/hub/' -p 7860:7860 ghcr.io/swivid/f5-tts:main f5-tts_infer-gradio --host 0.0.0.0
 ```
 
 


### PR DESCRIPTION
Adding `VOLUME` to the Dockerfile gives a hint to users about which folders they probably want to mount to avoid excessive data fetching from the internet.

Adding `EXPOSE` to the Dockerfile gives a hint to users about which port they probably want to expose to access the web service under default configuration.

Adding a more complete `docker container run` command lets people quickly get started with the project with a single copyable command.

Adding the GUI run command gives a simple to use quickstart command for users that don't want to do a deep dive into understanding everything and they just want a GUI.

----

It may be worth moving the Docker quickstart command to the top of the Readme, as it is the fastest/easiest way to get things going, but I didn't want to make that big of a change in this PR without buy-in from the maintainers.