### PR TITLE
fix: Incorrect calculation of duration

### DIFF
--- a/src/f5_tts/infer/utils_infer.py
+++ b/src/f5_tts/infer/utils_infer.py
@@ -462,7 +462,8 @@ def infer_batch_process(
 
         ref_audio_len = audio.shape[-1] // hop_length
         if fix_duration is not None:
-            duration = int(fix_duration * target_sample_rate / hop_length)
+            generated_duration = int(fix_duration * target_sample_rate / hop_length)
+            duration = ref_audio_len + generated_duration
         else:
             # Calculate duration
             ref_text_len = len(ref_text.encode("utf-8"))


### PR DESCRIPTION
What my PR does: Fixed the issue where the generated audio duration would be 0 seconds (or 0.x seconds) when passing `fix_duration`. Now the `fix_duration` parameter will take effect, generating audio with the fixed specified duration.

Original code:
```python
        if fix_duration is not None:
            duration = int(fix_duration * target_sample_rate / hop_length)
        else:
            # Calculate duration
            ref_text_len = len(ref_text.encode("utf-8"))
            gen_text_len = len(gen_text.encode("utf-8"))
            duration = ref_audio_len + int(ref_audio_len / ref_text_len * gen_text_len / local_speed)
```

As you can see, when the `fix_duration` parameter is not used, the actual `duration` used for model inference is derived from the sum of `ref_text_len` and `gen_text_len`. The model needs to know the total duration of the reference audio + the to-be-generated audio to determine the final audio duration.

Therefore, when passing `fix_duration` (which represents the desired fixed duration of the final generated audio), we also need to add the reference audio duration. That is:

Patch:
```python
        if fix_duration is not None:
            generated_duration = int(fix_duration * target_sample_rate / hop_length)
            duration = ref_audio_len + generated_duration
        else:
            # Calculate duration
            ref_text_len = len(ref_text.encode("utf-8"))
            gen_text_len = len(gen_text.encode("utf-8"))
            duration = ref_audio_len + int(ref_audio_len / ref_text_len * gen_text_len / local_speed)
```

This code modification **has been tested**. The original code would result in generated audio with a duration of 0 seconds when passing `fix_duration` (meaning the model only generated audio for the reference duration). In my patch, after passing `fix_duration`, the generated audio duration is fixed to the `fix_duration` time.