### PR TITLE
fix: use pydantic==2.10.6 to avoid bool is not iterable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "librosa",
     "matplotlib",
     "numpy<=1.26.4",
+    "pydantic==2.10.6",
     "pydub",
     "pypinyin",
     "safetensors",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "librosa",
     "matplotlib",
     "numpy<=1.26.4",
-    "pydantic==2.10.6",
+    "pydantic<=2.10.6",
     "pydub",
     "pypinyin",
     "safetensors",


### PR DESCRIPTION
when start gradio got below error, based on [this issue](https://github.com/gradio-app/gradio/issues/10649#issuecomment-2675018488) use `pydantic==2.10.6` can solve the issue

```
    if "const" in schema:
TypeError: argument of type 'bool' is not iterable
ERROR:    Exception in ASGI application
```