### PR TITLE
chore: Update the model checkpoint path to use the cache path.

### DIFF
--- a/src/f5_tts/infer/speech_edit.py
+++ b/src/f5_tts/infer/speech_edit.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 import torchaudio
 from hydra.utils import get_class
 from omegaconf import OmegaConf
+from cached_path import cached_path
 
 from f5_tts.infer.utils_infer import load_checkpoint, load_vocoder, save_spectrogram
 from f5_tts.model import CFM
@@ -55,7 +56,8 @@ win_length = model_cfg.model.mel_spec.win_length
 n_fft = model_cfg.model.mel_spec.n_fft
 
 
-ckpt_path = str(files("f5_tts").joinpath("../../")) + f"ckpts/{exp_name}/model_{ckpt_step}.safetensors"
+# ckpt_path = str(files("f5_tts").joinpath("../../")) + f"/ckpts/{exp_name}/model_{ckpt_step}.safetensors"
+ckpt_path = str(cached_path(f"hf://SWivid/F5-TTS/{exp_name}/model_{ckpt_step}.safetensors"))
 output_dir = "tests"
 
 


### PR DESCRIPTION
When I was trying to test `speech_edit.py`, I discovered the following error, which seems to point to a folder in the current repo. However, I see that `infer_gradio.py` and `infer_cli.py` both use cache paths, so I made modifications to it.

```
(f5-tts) ➜  F5-TTS git:(main) python src/f5_tts/infer/speech_edit.py
Download Vocos from huggingface charactr/vocos-mel-24khz
Traceback (most recent call last):
  File "/Users/tbxark/Desktop/Repos/github/F5-TTS/src/f5_tts/infer/speech_edit.py", line 125, in <module>
    model = load_checkpoint(model, ckpt_path, device, dtype=dtype, use_ema=use_ema)
  File "/Users/tbxark/Desktop/Repos/github/F5-TTS/src/f5_tts/infer/utils_infer.py", line 200, in load_checkpoint
    checkpoint = load_file(ckpt_path, device=device)
  File "/opt/homebrew/anaconda3/envs/f5-tts/lib/python3.10/site-packages/safetensors/torch.py", line 313, in load_file
    with safe_open(filename, framework="pt", device=device) as f:
FileNotFoundError: No such file or directory: "/Users/tbxark/Desktop/Repos/github/F5-TTS/src/f5_tts/../../ckpts/F5TTS_v1_Base/model_1250000.safetensors"
```