### PR TITLE
Fix the duration computation in `triton_trtllm/client_grpc.py`

### DIFF
--- a/src/f5_tts/runtime/triton_trtllm/client_grpc.py
+++ b/src/f5_tts/runtime/triton_trtllm/client_grpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+    #!/usr/bin/env python3
 # Copyright      2022  Xiaomi Corp.        (authors: Fangjun Kuang)
 #                2023  Nvidia              (authors: Yuekai Zhang)
 #                2023  Recurrent.ai        (authors: Songtao Shi)
@@ -310,8 +310,9 @@ async def send(
         audio_save_path = os.path.join(audio_save_dir, f"{item['target_audio_path']}.wav")
         sf.write(audio_save_path, audio, save_sample_rate, "PCM_16")
 
-        latency_data.append((end, estimated_target_duration))
-        total_duration += estimated_target_duration
+        actual_duration = len(audio) / save_sample_rate
+        latency_data.append((end, actual_duration))
+        total_duration += actual_duration
 
     return total_duration, latency_data
 

--- a/src/f5_tts/runtime/triton_trtllm/client_grpc.py
+++ b/src/f5_tts/runtime/triton_trtllm/client_grpc.py
@@ -1,4 +1,4 @@
-    #!/usr/bin/env python3
+#!/usr/bin/env python3
 # Copyright      2022  Xiaomi Corp.        (authors: Fangjun Kuang)
 #                2023  Nvidia              (authors: Yuekai Zhang)
 #                2023  Recurrent.ai        (authors: Songtao Shi)


### PR DESCRIPTION
This PR aims to update the computation of metrics such as RTF by using `actual_duration` instead of the currently used estimated values.

Currently, in the codebase, `total_duration` is calculated based on an estimated target duration:

```python
# src/f5_tts/runtime/triton_trtllm/client_grpc.py
estimated_target_duration = duration / len(reference_text) * len(target_text)

latency_data.append((end, estimated_target_duration))
total_duration += estimated_target_duration

rtf = elapsed / total_duration
```

This change will allow for more accurate metric calculation by relying on actual measured durations rather than estimations. When the length of target text is long enough, estimated durations and actual ones can differ significantly.

