### PR TITLE
Update WAV File Naming and Dependencies 📝🔊

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ dependencies = [
     "tqdm>=4.65.0",
     "transformers",
     "transformers_stream_generator",
+    "unidecode",
     "vocos",
     "wandb",
-    "unidecode",
     "x_transformers>=1.31.14",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "transformers_stream_generator",
     "vocos",
     "wandb",
-    "unidecode"
+    "unidecode",
     "x_transformers>=1.31.14",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "transformers_stream_generator",
     "vocos",
     "wandb",
+    "unidecode"
     "x_transformers>=1.31.14",
 ]
 

--- a/src/f5_tts/infer/infer_cli.py
+++ b/src/f5_tts/infer/infer_cli.py
@@ -5,6 +5,7 @@ import re
 from datetime import datetime
 from importlib.resources import files
 from pathlib import Path
+from unidecode import unidecode
 
 import numpy as np
 import soundfile as sf
@@ -345,7 +346,7 @@ def main():
             if len(gen_text_) > 200:
                 gen_text_ = gen_text_[:200] + " ... "
             sf.write(
-                os.path.join(output_chunk_dir, f"{len(generated_audio_segments) - 1}_{gen_text_}.wav"),
+                os.path.join(output_chunk_dir, f"{len(generated_audio_segments) - 1}_{unidecode(gen_text_)}.wav"),
                 audio_segment,
                 final_sample_rate,
             )

--- a/src/f5_tts/infer/infer_cli.py
+++ b/src/f5_tts/infer/infer_cli.py
@@ -5,7 +5,6 @@ import re
 from datetime import datetime
 from importlib.resources import files
 from pathlib import Path
-from unidecode import unidecode
 
 import numpy as np
 import soundfile as sf
@@ -13,6 +12,7 @@ import tomli
 from cached_path import cached_path
 from hydra.utils import get_class
 from omegaconf import OmegaConf
+from unidecode import unidecode
 
 from f5_tts.infer.utils_infer import (
     cfg_strength,
@@ -114,6 +114,11 @@ parser.add_argument(
     help="To save each audio chunks during inference",
 )
 parser.add_argument(
+    "--no_legacy_text",
+    action="store_false",
+    help="Not to use lossy ASCII transliterations of unicode text in saved file names.",
+)
+parser.add_argument(
     "--remove_silence",
     action="store_true",
     help="To remove long silence found in ouput",
@@ -198,6 +203,12 @@ output_file = args.output_file or config.get(
 )
 
 save_chunk = args.save_chunk or config.get("save_chunk", False)
+use_legacy_text = args.no_legacy_text or config.get("no_legacy_text", False)  # no_legacy_text is a store_false arg
+if save_chunk and use_legacy_text:
+    print(
+        "\nWarning to --save_chunk: lossy ASCII transliterations of unicode text for legacy (.wav) file names, --no_legacy_text to disable.\n"
+    )
+
 remove_silence = args.remove_silence or config.get("remove_silence", False)
 load_vocoder_from_local = args.load_vocoder_from_local or config.get("load_vocoder_from_local", False)
 
@@ -345,8 +356,10 @@ def main():
         if save_chunk:
             if len(gen_text_) > 200:
                 gen_text_ = gen_text_[:200] + " ... "
+            if use_legacy_text:
+                gen_text_ = unidecode(gen_text_)
             sf.write(
-                os.path.join(output_chunk_dir, f"{len(generated_audio_segments) - 1}_{unidecode(gen_text_)}.wav"),
+                os.path.join(output_chunk_dir, f"{len(generated_audio_segments) - 1}_{gen_text_}.wav"),
                 audio_segment,
                 final_sample_rate,
             )


### PR DESCRIPTION

-   Added `unidecode` to `pyproject.toml` dependencies for ASCII text normalization 📚.
    
-   Modified `infer_cli.py` to use `unidecode` for WAV file names of audio chunks 🎵. Previously, raw `gen_text_` could include non-ASCII characters (e.g., "Téxt" → "Text", "こんにちは" → "konnichiha", or Vietnamese "Tiếng Việt" → "Tieng Viet"), risking file system errors 🚫. Now, `unidecode` ensures ASCII-compliant names, maintaining the format `index_unidecoded_text.wav`. This enhances cross-platform compatibility and prevents naming issues on systems with strict character restrictions 🌐.