### PR TITLE
Fix raw.arrow missing rows

### DIFF
--- a/src/f5_tts/train/datasets/prepare_csv_wavs.py
+++ b/src/f5_tts/train/datasets/prepare_csv_wavs.py
@@ -213,6 +213,7 @@ def save_prepped_dataset(out_dir, result, duration_list, text_vocab_set, is_fine
     with ArrowWriter(path=raw_arrow_path.as_posix(), writer_batch_size=100) as writer:
         for line in tqdm(result, desc="Writing to raw.arrow ..."):
             writer.write(line)
+        writer.finalize()
 
     # Save durations to JSON
     dur_json_path = out_dir / "duration.json"

--- a/src/f5_tts/train/datasets/prepare_emilia.py
+++ b/src/f5_tts/train/datasets/prepare_emilia.py
@@ -178,9 +178,10 @@ def main():
 
     # dataset = Dataset.from_dict({"audio_path": audio_path_list, "text": text_list, "duration": duration_list})  # oom
     # dataset.save_to_disk(f"{save_dir}/raw", max_shard_size="2GB")
-    with ArrowWriter(path=f"{save_dir}/raw.arrow") as writer:
+    with ArrowWriter(path=f"{save_dir}/raw.arrow", writer_batch_size=100) as writer:
         for line in tqdm(result, desc="Writing to raw.arrow ..."):
             writer.write(line)
+        writer.finalize()
 
     # dup a json separately saving duration in case for DynamicBatchSampler ease
     with open(f"{save_dir}/duration.json", "w", encoding="utf-8") as f:

--- a/src/f5_tts/train/datasets/prepare_emilia_v2.py
+++ b/src/f5_tts/train/datasets/prepare_emilia_v2.py
@@ -65,9 +65,10 @@ def main():
     if not os.path.exists(f"{save_dir}"):
         os.makedirs(f"{save_dir}")
 
-    with ArrowWriter(path=f"{save_dir}/raw.arrow") as writer:
+    with ArrowWriter(path=f"{save_dir}/raw.arrow", writer_batch_size=100) as writer:
         for line in tqdm(result, desc="Writing to raw.arrow ..."):
             writer.write(line)
+        writer.finalize()
 
     with open(f"{save_dir}/duration.json", "w", encoding="utf-8") as f:
         json.dump({"duration": duration_list}, f, ensure_ascii=False)

--- a/src/f5_tts/train/datasets/prepare_libritts.py
+++ b/src/f5_tts/train/datasets/prepare_libritts.py
@@ -59,9 +59,10 @@ def main():
         os.makedirs(f"{save_dir}")
     print(f"\nSaving to {save_dir} ...")
 
-    with ArrowWriter(path=f"{save_dir}/raw.arrow") as writer:
+    with ArrowWriter(path=f"{save_dir}/raw.arrow", writer_batch_size=100) as writer:
         for line in tqdm(result, desc="Writing to raw.arrow ..."):
             writer.write(line)
+        writer.finalize()
 
     # dup a json separately saving duration in case for DynamicBatchSampler ease
     with open(f"{save_dir}/duration.json", "w", encoding="utf-8") as f:

--- a/src/f5_tts/train/datasets/prepare_ljspeech.py
+++ b/src/f5_tts/train/datasets/prepare_ljspeech.py
@@ -36,9 +36,10 @@ def main():
         os.makedirs(f"{save_dir}")
     print(f"\nSaving to {save_dir} ...")
 
-    with ArrowWriter(path=f"{save_dir}/raw.arrow") as writer:
+    with ArrowWriter(path=f"{save_dir}/raw.arrow", writer_batch_size=100) as writer:
         for line in tqdm(result, desc="Writing to raw.arrow ..."):
             writer.write(line)
+        writer.finalize()
 
     # dup a json separately saving duration in case for DynamicBatchSampler ease
     with open(f"{save_dir}/duration.json", "w", encoding="utf-8") as f:

--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -799,6 +799,7 @@ def create_metadata(name_project, ch_tokenizer, progress=gr.Progress()):
     with ArrowWriter(path=file_raw, writer_batch_size=1) as writer:
         for line in progress.tqdm(result, total=len(result), desc="prepare data"):
             writer.write(line)
+        writer.finalize()
 
     with open(file_duration, "w") as f:
         json.dump({"duration": duration_list}, f, ensure_ascii=False)

--- a/src/f5_tts/train/finetune_gradio.py
+++ b/src/f5_tts/train/finetune_gradio.py
@@ -796,7 +796,8 @@ def create_metadata(name_project, ch_tokenizer, progress=gr.Progress()):
     min_second = round(min(duration_list), 2)
     max_second = round(max(duration_list), 2)
 
-    with ArrowWriter(path=file_raw, writer_batch_size=1) as writer:
+    # Save dataset with improved batch size for better I/O performance
+    with ArrowWriter(path=file_raw, writer_batch_size=100) as writer:
         for line in progress.tqdm(result, total=len(result), desc="prepare data"):
             writer.write(line)
         writer.finalize()


### PR DESCRIPTION
Hi,

first of all: Thanks for F5-TTS! 😊

I noticed that some data was missing in the `raw.arrow` files created by `prepare_csv_wavs.py`. This is due to the writer batch size of 100 and the missing `finalize()` call.

```python
with ArrowWriter(path=raw_arrow_path.as_posix(), writer_batch_size=100) as writer:
    for line in tqdm(result, desc="Writing raw.arrow"):
        writer.write(line)
    # writer.finalize()
```

This PR 

1. adds the missing line
2. adds `writer_batch_size=100` and `writer.finalize()` to the Gradio script and other dataset preparation scripts.

Kind regards,
Jim