### PR TITLE
added tensorboard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "vocos",
     "wandb",
     "x_transformers>=1.31.14",
+    "tensorboard>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
tensorboard exists as a logger option on training section of Gradio, but there was no dependency installation for it