### PR TITLE
Ignore padding at the end of the GT mel spectrogram when training sample

### DIFF
--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -420,7 +420,7 @@ class Trainer:
                             )
                             generated = generated.to(torch.float32)
                             gen_mel_spec = generated[:, ref_audio_len:, :].permute(0, 2, 1).to(self.accelerator.device)
-                            ref_mel_spec = batch["mel"][0].unsqueeze(0)
+                            ref_mel_spec = batch["mel"][0, :, :ref_audio_len].unsqueeze(0)
                             if self.vocoder_name == "vocos":
                                 gen_audio = vocoder.decode(gen_mel_spec).cpu()
                                 ref_audio = vocoder.decode(ref_mel_spec).cpu()


### PR DESCRIPTION
<img width="3012" height="1464" alt="image" src="https://github.com/user-attachments/assets/50d3d403-00b1-4203-9106-0c9df28db3a9" />
 
fix this situation and use the GT ref_audio_len to ignore padding