### PR TITLE
fix: tensor shape mismatch in batch inference due to cache race condition (#1287)

### DIFF
--- a/src/f5_tts/infer/utils_infer.py
+++ b/src/f5_tts/infer/utils_infer.py
@@ -537,14 +537,22 @@ def infer_batch_process(
             for chunk in infer_single_process_streaming(gen_text):
                 yield chunk
     else:
-        with ThreadPoolExecutor() as executor:
-            futures = [executor.submit(infer_single_process, gen_text) for gen_text in gen_text_batches]
-            for future in progress.tqdm(futures) if progress is not None else futures:
-                result = future.result()
-                if result:
-                    generated_wave, generated_mel_spec = result
-                    generated_waves.append(generated_wave)
-                    spectrograms.append(generated_mel_spec)
+        # NOTE: Do NOT use ThreadPoolExecutor here — the model's transformer
+        # has a shared text-embedding cache (text_cond / text_uncond) that is
+        # populated inside model.sample() and read on every ODE-step call to
+        # get_input_embed().  Running multiple sample() calls concurrently on
+        # the same model causes cache races: Thread-B overwrites the cached
+        # text_embed while Thread-A is still iterating through odeint steps,
+        # leading to shape mismatches like:
+        #   RuntimeError: Sizes of tensors must match except in dimension 2.
+        #   Expected size 1757 but got size 1733
+        # See: https://github.com/SWivid/F5-TTS/issues/1287
+        for gen_text in gen_text_batches:
+            result = infer_single_process(gen_text)
+            if result:
+                generated_wave, generated_mel_spec = result
+                generated_waves.append(generated_wave)
+                spectrograms.append(generated_mel_spec)
 
         if generated_waves:
             if cross_fade_duration <= 0:


### PR DESCRIPTION
## Problem

When generating audio for text longer than one batch, `infer_batch_process()` uses `ThreadPoolExecutor` to run multiple `model.sample()` calls concurrently on the same model instance.

However, the DiT transformer has a **shared text-embedding cache** (`text_cond` / `text_uncond`) in `get_input_embed()` that is populated during `sample()` and read on every ODE step. Concurrent threads overwrite each other's cached `text_embed` that has a different `seq_len` value.

### Race condition timeline

```
Thread A (batch 1, seq_len=1757)    Thread B (batch 2, seq_len=1733)
─────────────────────────────       ─────────────────────────────
get_input_embed() → compute text_embed with seq_len=1757
stores to self.text_cond
                                    get_input_embed() → compute text_embed with seq_len=1733
                                    overwrites self.text_cond
odeint fn() → reads self.text_cond (now 1733!)
torch.cat((x[1757], cond[1757], text_embed[1733])) → 💥
```

### Error

```
RuntimeError: Sizes of tensors must match except in dimension 2.
Expected size 1757 but got size 1733 for tensor number 2 in the list.
```

## Fix

Replace `ThreadPoolExecutor` with sequential batch processing. Each `sample()` call now completes before the next one starts, eliminating the cache race.

The parallelism was a minor optimization (each batch is already GPU-bound), but introduced a correctness bug. Sequential processing is the simplest and most robust fix.

## Testing

The fix can be verified by:
1. Using a reference audio + text longer than one batch (triggers multi-batch path)
2. Previously: `RuntimeError` tensor shape mismatch
3. After fix: audio generates successfully across batches

Fixes #1287