### PR TITLE
Update AMD ROCm install to 7.2 for RDNA 3.5/4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,17 @@ conda install ffmpeg
 
 > ```bash
 > # Install pytorch with your ROCm version (Linux only), e.g.
-> pip install torch==2.5.1+rocm6.2 torchaudio==2.5.1+rocm6.2 --extra-index-url https://download.pytorch.org/whl/rocm6.2
+> pip install torch==2.9.1+rocm7.2 torchaudio==2.9.1+rocm7.2 --extra-index-url https://download.pytorch.org/whl/rocm7.2
+>
+> # For older GPUs (RDNA1/2/3 only):
+> # pip install torch==2.5.1+rocm6.2 torchaudio==2.5.1+rocm6.2 --extra-index-url https://download.pytorch.org/whl/rocm6.2
 > ```
+>
+> **Note:** RDNA 3.5 and RDNA 4 GPUs (Radeon 8050S/8060S, RX 9060/9070 series) require
+> ROCm 7.x — these architectures (gfx1151/gfx1201) are not included in ROCm 6.x
+> ([6.2 compatibility matrix](https://rocm.docs.amd.com/en/docs-6.2.4/compatibility/compatibility-matrix.html) vs
+> [7.2 compatibility matrix](https://rocm.docs.amd.com/en/docs-7.2.3/compatibility/compatibility-matrix.html)).
+> Using ROCm 6.x on these GPUs causes `HIP error: invalid device function` ([#1236](https://github.com/SWivid/F5-TTS/issues/1236)).
 
 </details>
 


### PR DESCRIPTION
## Summary

The README recommends `torch==2.5.1+rocm6.2` for AMD GPUs, but ROCm 6.x does not include gfx1151 or gfx1201 targets. Users with RDNA 3.5/4 GPUs (Radeon 8050S/8060S, RX 9060/9070) hit `HIP error: invalid device function` on first model load (#1236).

## Changes

- Default PyTorch recommendation → `torch==2.9.1+rocm7.2`
- Old ROCm 6.2 command preserved as comment for RDNA1/2/3 users
- Added note with links to official ROCm 6.2 vs 7.2 compatibility matrices confirming the architecture gap

## References

- Issue: #1236
- ROCm 6.2 compat matrix (no gfx1201): https://rocm.docs.amd.com/en/docs-6.2.4/compatibility/compatibility-matrix.html
- ROCm 7.2 compat matrix (has gfx1201): https://rocm.docs.amd.com/en/docs-7.2.3/compatibility/compatibility-matrix.html