### PR TITLE
fix: allocate fix_duration across chunks to avoid N× duration blow-up

### DIFF
--- a/src/f5_tts/infer/utils_infer.py
+++ b/src/f5_tts/infer/utils_infer.py
@@ -474,7 +474,19 @@ def infer_batch_process(
     if len(ref_text[-1].encode("utf-8")) == 1:
         ref_text = ref_text + " "
 
-    def _infer_basic(gen_text):
+    # Allocate fix_duration across chunks to avoid each chunk using the full-sentence duration (N× blow-up)
+    if fix_duration is not None and len(gen_text_batches) > 1:
+        ref_audio_len_frames = audio.shape[-1] // hop_length
+        ref_sec = ref_audio_len_frames * hop_length / target_sample_rate
+        target_total = fix_duration - ref_sec
+        weights = [len(c.encode("utf-8")) for c in gen_text_batches]
+        total_w = sum(weights)
+        allocatable = target_total + cross_fade_duration * (len(gen_text_batches) - 1)
+        fix_durations = [ref_sec + allocatable * w / total_w for w in weights]
+    else:
+        fix_durations = [fix_duration] * len(gen_text_batches)
+
+    def _infer_basic(gen_text, fix_dur):
         local_speed = speed
         if len(gen_text.encode("utf-8")) < 10:
             local_speed = 0.3
@@ -484,8 +496,8 @@ def infer_batch_process(
         final_text_list = convert_char_to_pinyin(text_list)
 
         ref_audio_len = audio.shape[-1] // hop_length
-        if fix_duration is not None:
-            duration = int(fix_duration * target_sample_rate / hop_length)
+        if fix_dur is not None:
+            duration = int(fix_dur * target_sample_rate / hop_length)
         else:
             # Calculate duration
             ref_text_len = len(ref_text.encode("utf-8"))
@@ -519,26 +531,27 @@ def infer_batch_process(
 
         return generated_wave, generated
 
-    def infer_single_process(gen_text):
-        generated_wave, generated = _infer_basic(gen_text)
+    def infer_single_process(gen_text, fix_dur):
+        generated_wave, generated = _infer_basic(gen_text, fix_dur)
         generated_cpu = generated[0].cpu().numpy()
         del generated
         return generated_wave, generated_cpu
 
-    def infer_single_process_streaming(gen_text):
+    def infer_single_process_streaming(gen_text, fix_dur):
         # for src/f5_tts/socket_server.py
-        generated_wave, generated = _infer_basic(gen_text)
+        generated_wave, generated = _infer_basic(gen_text, fix_dur)
         del generated
         for j in range(0, len(generated_wave), chunk_size):
             yield generated_wave[j : j + chunk_size], target_sample_rate
 
     if streaming:
-        for gen_text in progress.tqdm(gen_text_batches) if progress is not None else gen_text_batches:
-            for chunk in infer_single_process_streaming(gen_text):
+        batches_iter = progress.tqdm(gen_text_batches) if progress is not None else gen_text_batches
+        for gen_text, fix_dur in zip(batches_iter, fix_durations):
+            for chunk in infer_single_process_streaming(gen_text, fix_dur):
                 yield chunk
     else:
         with ThreadPoolExecutor() as executor:
-            futures = [executor.submit(infer_single_process, gen_text) for gen_text in gen_text_batches]
+            futures = [executor.submit(infer_single_process, gt, fd) for gt, fd in zip(gen_text_batches, fix_durations)]
             for future in progress.tqdm(futures) if progress is not None else futures:
                 result = future.result()
                 if result:


### PR DESCRIPTION
Hi F5-TTS maintainers,

Fixes #1308

## 问题

`infer_process()` 对长文本自动分包(`chunk_text()`),但把同一个标量 `fix_duration` 原样传给 `infer_batch_process()`。其中 `_infer_basic()` 对每个 chunk 都执行:

```python
if fix_duration is not None:
    duration = int(fix_duration * target_sample_rate / hop_length)
```

即每个 chunk 都按整句 `fix_duration` 生成;裁掉参考音频后每段 ≈ `fix_duration - ref_duration` = 一个完整 `target`,N 段拼接 ≈ `N × target`。下游再用 time-stretch 压回 = N 倍速感。

`fix_duration=None` 分支不受影响(每 chunk 按自己的 `gen_text_len` 估时)。

## 证据

`ref=9.66s, target=17.14s, fix_duration=26.80s`,一句被切成 2 batch:

```
Generating audio in 2 batches...
gen = 34.005s  (≈ 2 × 17.14 − 0.15 crossfade)
rubberband rate = 1.984  (压回 17.14s → ~2× 播放)
```

实测 1.984 与分析值 `33.85/17 ≈ 1.991` 吻合。

## 修复

多 chunk 时按 UTF-8 字节权重把 `fix_duration` 分摊给各 chunk,并补偿 `(N-1) × cross_fade_duration` 的重叠消耗;`_infer_basic` / `infer_single_process` / `infer_single_process_streaming` 改为接收该 chunk 的 `fix_dur`,不再用闭包标量。单 chunk 与 `fix_duration=None` 分支保持原样(`fix_durations = [fix_duration]`)。

```python
if fix_duration is not None and len(gen_text_batches) > 1:
    ref_sec = (audio.shape[-1] // hop_length) * hop_length / target_sample_rate
    target_total = fix_duration - ref_sec
    weights = [len(c.encode("utf-8")) for c in gen_text_batches]
    total_w = sum(weights)
    allocatable = target_total + cross_fade_duration * (len(gen_text_batches) - 1)
    fix_durations = [ref_sec + allocatable * w / total_w for w in weights]
else:
    fix_durations = [fix_duration] * len(gen_text_batches)
```

## 验证

同一句 2-batch:修复前 `gen=34.0s / ratio=1.984`,修复后 `gen=17.06s / ratio=0.995`,无需强 time-stretch。

## 备注

字节权重是第一近似;后续可改为按各 chunk 自然估时比例分配。本修复已消除 N 倍膨胀。