### PR TITLE
feat(train): integrate compile and distributed training hardening

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,53 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  cpu-gloo:
+    name: Python ${{ matrix.python }} / Torch ${{ matrix.torch }} / Accelerate ${{ matrix.accelerate }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python: "3.10"
+            torch: "2.0.1"
+            accelerate: "0.33.0"
+          - python: "3.12"
+            torch: "2.5.1"
+            accelerate: "1.14.0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - name: Install CPU test environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "torch==${{ matrix.torch }}" --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install \
+            "accelerate==${{ matrix.accelerate }}" \
+            datasets \
+            ema-pytorch \
+            librosa \
+            pypinyin \
+            rjieba \
+            pytest \
+            ruff \
+            torchdiffeq \
+            wandb \
+            x-transformers
+          python -m pip install --no-deps -e .
+      - name: Lint
+        run: python -m ruff check src tests
+      - name: Compile Python sources
+        run: python -m compileall -q src
+      - name: CPU and Gloo regression suite
+        env:
+          PYTHONPATH: src
+        run: python -m pytest -q

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
             pypinyin \
             rjieba \
             pytest \
-            ruff \
+            "ruff==0.11.2" \
             torchdiffeq \
             wandb \
             x-transformers

--- a/src/f5_tts/configs/E2TTS_Base.yaml
+++ b/src/f5_tts/configs/E2TTS_Base.yaml
@@ -16,6 +16,7 @@ optim:
   grad_accumulation_steps: 1  # note: updates = steps / grad_accumulation_steps
   max_grad_norm: 1.0  # gradient clipping
   bnb_optimizer: False  # use bnb 8bit AdamW optimizer or not
+  global_masked_mean: False  # equal-weight masked frames across accumulation/DDP
 
 model:
   name: E2TTS_Base

--- a/src/f5_tts/configs/E2TTS_Base.yaml
+++ b/src/f5_tts/configs/E2TTS_Base.yaml
@@ -50,3 +50,12 @@ ckpts:
   keep_last_n_checkpoints: -1  # -1 to keep all, 0 to not save intermediate, > 0 to keep last N checkpoints
   last_per_updates: 5000  # save last checkpoint per updates
   save_dir: ckpts/${model.name}_${model.mel_spec.mel_spec_type}_${model.tokenizer}_${datasets.name}
+
+compile:
+  enabled: False  # optional torch.compile path; disabled by default
+  target: cfm_loss_core  # cfm_loss_core | dit_blocks
+  backend: inductor  # requires triton on CUDA
+  mode: null
+  fullgraph: False
+  dynamic: null  # modern Torch auto-detects shapes; legacy static-default Torch resolves null to True
+  fallback_to_eager: True  # fall back to eager if compile setup fails (runtime fallback disabled in DDP)

--- a/src/f5_tts/configs/E2TTS_Small.yaml
+++ b/src/f5_tts/configs/E2TTS_Small.yaml
@@ -50,3 +50,12 @@ ckpts:
   keep_last_n_checkpoints: -1  # -1 to keep all, 0 to not save intermediate, > 0 to keep last N checkpoints
   last_per_updates: 5000  # save last checkpoint per updates
   save_dir: ckpts/${model.name}_${model.mel_spec.mel_spec_type}_${model.tokenizer}_${datasets.name}
+
+compile:
+  enabled: False  # optional torch.compile path; disabled by default
+  target: cfm_loss_core  # cfm_loss_core | dit_blocks
+  backend: inductor  # requires triton on CUDA
+  mode: null
+  fullgraph: False
+  dynamic: null  # modern Torch auto-detects shapes; legacy static-default Torch resolves null to True
+  fallback_to_eager: True  # fall back to eager if compile setup fails (runtime fallback disabled in DDP)

--- a/src/f5_tts/configs/E2TTS_Small.yaml
+++ b/src/f5_tts/configs/E2TTS_Small.yaml
@@ -16,6 +16,7 @@ optim:
   grad_accumulation_steps: 1  # note: updates = steps / grad_accumulation_steps
   max_grad_norm: 1.0
   bnb_optimizer: False  
+  global_masked_mean: False  # equal-weight masked frames across accumulation/DDP
 
 model:
   name: E2TTS_Small

--- a/src/f5_tts/configs/F5TTS_Base.yaml
+++ b/src/f5_tts/configs/F5TTS_Base.yaml
@@ -16,6 +16,7 @@ optim:
   grad_accumulation_steps: 1  # note: updates = steps / grad_accumulation_steps
   max_grad_norm: 1.0  # gradient clipping
   bnb_optimizer: False  # use bnb 8bit AdamW optimizer or not
+  global_masked_mean: False  # equal-weight masked frames across accumulation/DDP
 
 model:
   name: F5TTS_Base  # model name

--- a/src/f5_tts/configs/F5TTS_Base.yaml
+++ b/src/f5_tts/configs/F5TTS_Base.yaml
@@ -55,3 +55,12 @@ ckpts:
   keep_last_n_checkpoints: -1  # -1 to keep all, 0 to not save intermediate, > 0 to keep last N checkpoints
   last_per_updates: 5000  # save last checkpoint per updates
   save_dir: ckpts/${model.name}_${model.mel_spec.mel_spec_type}_${model.tokenizer}_${datasets.name}
+
+compile:
+  enabled: False  # optional torch.compile path; disabled by default
+  target: dit_blocks  # dit_blocks | cfm_loss_core
+  backend: inductor  # requires triton on CUDA
+  mode: null
+  fullgraph: False
+  dynamic: null  # modern Torch auto-detects shapes; legacy static-default Torch resolves null to True
+  fallback_to_eager: True  # fall back to eager if compile setup fails (runtime fallback disabled in DDP)

--- a/src/f5_tts/configs/F5TTS_Small.yaml
+++ b/src/f5_tts/configs/F5TTS_Small.yaml
@@ -55,3 +55,12 @@ ckpts:
   keep_last_n_checkpoints: -1  # -1 to keep all, 0 to not save intermediate, > 0 to keep last N checkpoints
   last_per_updates: 5000  # save last checkpoint per updates
   save_dir: ckpts/${model.name}_${model.mel_spec.mel_spec_type}_${model.tokenizer}_${datasets.name}
+
+compile:
+  enabled: False  # optional torch.compile path; disabled by default
+  target: dit_blocks  # dit_blocks | cfm_loss_core
+  backend: inductor  # requires triton on CUDA
+  mode: null
+  fullgraph: False
+  dynamic: null  # modern Torch auto-detects shapes; legacy static-default Torch resolves null to True
+  fallback_to_eager: True  # fall back to eager if compile setup fails (runtime fallback disabled in DDP)

--- a/src/f5_tts/configs/F5TTS_Small.yaml
+++ b/src/f5_tts/configs/F5TTS_Small.yaml
@@ -16,6 +16,7 @@ optim:
   grad_accumulation_steps: 1  # note: updates = steps / grad_accumulation_steps
   max_grad_norm: 1.0  # gradient clipping
   bnb_optimizer: False  # use bnb 8bit AdamW optimizer or not
+  global_masked_mean: False  # equal-weight masked frames across accumulation/DDP
 
 model:
   name: F5TTS_Small

--- a/src/f5_tts/configs/F5TTS_v1_Base.yaml
+++ b/src/f5_tts/configs/F5TTS_v1_Base.yaml
@@ -56,3 +56,12 @@ ckpts:
   keep_last_n_checkpoints: -1  # -1 to keep all, 0 to not save intermediate, > 0 to keep last N checkpoints
   last_per_updates: 5000  # save last checkpoint per updates
   save_dir: ckpts/${model.name}_${model.mel_spec.mel_spec_type}_${model.tokenizer}_${datasets.name}
+
+compile:
+  enabled: False  # optional torch.compile path; disabled by default
+  target: dit_blocks  # dit_blocks | cfm_loss_core
+  backend: inductor  # requires triton on CUDA
+  mode: null
+  fullgraph: False
+  dynamic: null  # modern Torch auto-detects shapes; legacy static-default Torch resolves null to True
+  fallback_to_eager: True  # fall back to eager if compile setup fails (runtime fallback disabled in DDP)

--- a/src/f5_tts/configs/F5TTS_v1_Base.yaml
+++ b/src/f5_tts/configs/F5TTS_v1_Base.yaml
@@ -16,6 +16,7 @@ optim:
   grad_accumulation_steps: 1  # note: updates = steps / grad_accumulation_steps
   max_grad_norm: 1.0  # gradient clipping
   bnb_optimizer: False  # use bnb 8bit AdamW optimizer or not
+  global_masked_mean: False  # equal-weight masked frames across accumulation/DDP
 
 model:
   name: F5TTS_v1_Base  # model name

--- a/src/f5_tts/configs/F5TTS_v1_Small.yaml
+++ b/src/f5_tts/configs/F5TTS_v1_Small.yaml
@@ -56,3 +56,12 @@ ckpts:
   keep_last_n_checkpoints: -1  # -1 to keep all, 0 to not save intermediate, > 0 to keep last N checkpoints
   last_per_updates: 5000  # save last checkpoint per updates
   save_dir: ckpts/${model.name}_${model.mel_spec.mel_spec_type}_${model.tokenizer}_${datasets.name}
+
+compile:
+  enabled: False  # optional torch.compile path; disabled by default
+  target: dit_blocks  # dit_blocks | cfm_loss_core
+  backend: inductor  # requires triton on CUDA
+  mode: null
+  fullgraph: False
+  dynamic: null  # modern Torch auto-detects shapes; legacy static-default Torch resolves null to True
+  fallback_to_eager: True  # fall back to eager if compile setup fails (runtime fallback disabled in DDP)

--- a/src/f5_tts/configs/F5TTS_v1_Small.yaml
+++ b/src/f5_tts/configs/F5TTS_v1_Small.yaml
@@ -16,6 +16,7 @@ optim:
   grad_accumulation_steps: 1  # note: updates = steps / grad_accumulation_steps
   max_grad_norm: 1.0  # gradient clipping
   bnb_optimizer: False  # use bnb 8bit AdamW optimizer or not
+  global_masked_mean: False  # equal-weight masked frames across accumulation/DDP
 
 model:
   name: F5TTS_v1_Small  # model name

--- a/src/f5_tts/model/backbones/dit.py
+++ b/src/f5_tts/model/backbones/dit.py
@@ -324,7 +324,7 @@ class DiT(nn.Module):
     # and deserialized models must fall back to eager execution rather than silently share
     # the source closure or crash on pickle. This mirrors nn.Module's own handling of
     # ``_compiled_call_impl`` in __getstate__.
-    _DIT_COMPILE_ONLY_ATTRS = ("_dit_compile_target", "_compiled_dit_block_forwards")
+    _DIT_COMPILE_ONLY_ATTRS = ("_dit_compile_target", "_compiled_dit_block_forwards", "_cache_local")
 
     def __getstate__(self):
         # Match nn.Module.__getstate__ on newer PyTorch releases without relying on

--- a/src/f5_tts/model/backbones/dit.py
+++ b/src/f5_tts/model/backbones/dit.py
@@ -11,9 +11,11 @@ d - dimension
 from __future__ import annotations
 
 import threading
+from typing import cast
 
 import torch
 import torch.nn.functional as F
+import torch.utils.checkpoint
 from torch import nn
 from x_transformers.x_transformers import RotaryEmbedding
 
@@ -83,33 +85,42 @@ class TextEmbedding(nn.Module):
 
         return upsampled_text
 
-    def forward(self, text: int["b nt"], seq_len, drop_text=False):
-        text = text + 1  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
+    def forward(self, text: int["b nt"], seq_len, drop_text=False, valid_seq_lens=None):
+        text_tensor = (
+            cast(torch.Tensor, text) + 1
+        )  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
         valid_pos_mask = None
         if torch.is_tensor(seq_len):
-            seq_len = seq_len.to(device=text.device, dtype=torch.long)
-            max_seq_len = int(seq_len.max().item())
+            seq_len_tensor = seq_len.to(device=text_tensor.device, dtype=torch.long)
+            max_seq_len = int(seq_len_tensor.max().item())
+            if valid_seq_lens is None:
+                valid_seq_lens = seq_len_tensor
         else:
-            max_seq_len = int(seq_len)
+            # Keep SymInt (not int()) so dynamic-shape torch.compile does not specialize
+            # the graph per sequence length. In eager mode seq_len is already a Python int.
+            max_seq_len = seq_len
 
-        text = text[:, :max_seq_len]  # curtail if character tokens are more than the mel spec tokens
-        text = F.pad(text, (0, max_seq_len - text.shape[1]), value=0)
+        text_tensor = text_tensor[:, :max_seq_len]  # curtail if character tokens are more than the mel spec tokens
+        text_tensor = F.pad(text_tensor, (0, max_seq_len - text_tensor.shape[1]), value=0)
 
-        if torch.is_tensor(seq_len):
-            seq_pos = torch.arange(max_seq_len, device=text.device).unsqueeze(0)
-            valid_pos_mask = seq_pos < seq_len.unsqueeze(1)
-            text = text.masked_fill(~valid_pos_mask, 0)
+        if valid_seq_lens is not None:
+            valid_seq_lens = valid_seq_lens.to(device=text_tensor.device, dtype=torch.long)
+            seq_pos = torch.arange(max_seq_len, device=text_tensor.device).unsqueeze(0)
+            valid_pos_mask = seq_pos < valid_seq_lens.unsqueeze(1)
+            text_tensor = text_tensor.masked_fill(~valid_pos_mask, 0)
 
-        if self.mask_padding:
-            text_mask = text == 0
+        text_mask = text_tensor == 0
 
-        if drop_text:  # cfg for text
-            text = torch.zeros_like(text)
+        if torch.is_tensor(drop_text):
+            drop_text_flag = drop_text.to(device=text_tensor.device, dtype=torch.bool).reshape(())
+            text_tensor = torch.where(drop_text_flag, torch.zeros_like(text_tensor), text_tensor)
+        elif drop_text:  # cfg for text
+            text_tensor = torch.zeros_like(text_tensor)
 
-        text = self.text_embed(text)  # b n -> b n d
+        text_tensor = self.text_embed(text_tensor)  # b n -> b n d
         if valid_pos_mask is not None:
             # Keep short-sample tail strictly zero (equivalent to per-sample pad_sequence(..., 0)).
-            text = text.masked_fill(~valid_pos_mask.unsqueeze(-1), 0.0)
+            text_tensor = text_tensor.masked_fill(~valid_pos_mask.unsqueeze(-1), 0.0)
 
         # possible extra modeling
         if self.extra_modeling:
@@ -117,26 +128,30 @@ class TextEmbedding(nn.Module):
             freqs = self.freqs_cis[:max_seq_len, :]
             if valid_pos_mask is not None:
                 freqs = freqs.unsqueeze(0) * valid_pos_mask.unsqueeze(-1).to(freqs.dtype)
-            text = text + freqs
+            text_tensor = text_tensor + freqs
 
             # convnextv2 blocks
             if self.mask_padding:
-                text = text.masked_fill(text_mask.unsqueeze(-1).expand(-1, -1, text.size(-1)), 0.0)
+                text_tensor = text_tensor.masked_fill(text_mask.unsqueeze(-1).expand(-1, -1, text_tensor.size(-1)), 0.0)
                 for block in self.text_blocks:
-                    text = block(text)
-                    text = text.masked_fill(text_mask.unsqueeze(-1).expand(-1, -1, text.size(-1)), 0.0)
+                    text_tensor = block(text_tensor)
+                    text_tensor = text_tensor.masked_fill(
+                        text_mask.unsqueeze(-1).expand(-1, -1, text_tensor.size(-1)), 0.0
+                    )
             else:
-                text = self.text_blocks(text)
+                text_tensor = self.text_blocks(text_tensor)
 
         if self.average_upsampling:
-            if torch.is_tensor(seq_len):
-                target_lens = seq_len.to(device=text.device, dtype=torch.long)
+            if valid_seq_lens is not None:
+                target_lens = valid_seq_lens
+            elif torch.is_tensor(seq_len):
+                target_lens = seq_len.to(device=text_tensor.device, dtype=torch.long)
             else:
-                target_lens = torch.full((text.shape[0],), int(seq_len), device=text.device, dtype=torch.long)
+                target_lens = torch.full((text_tensor.shape[0],), seq_len, device=text_tensor.device, dtype=torch.long)
 
-            text = self.average_upsample_text_by_mask(text, ~text_mask, target_lens)
+            text_tensor = self.average_upsample_text_by_mask(text_tensor, ~text_mask, target_lens)
 
-        return text
+        return text_tensor
 
 
 # noised input audio and context mixing embedding
@@ -156,18 +171,26 @@ class InputEmbedding(nn.Module):
         drop_audio_cond=False,
         audio_mask: bool["b n"] | None = None,
     ):
-        if drop_audio_cond:  # cfg for cond audio
-            cond = torch.zeros_like(cond)
+        x_tensor = cast(torch.Tensor, x)
+        cond_tensor = cast(torch.Tensor, cond)
+        text_embed_tensor = cast(torch.Tensor, text_embed)
+        if torch.is_tensor(drop_audio_cond):
+            drop_audio_cond_flag = drop_audio_cond.to(device=cond_tensor.device, dtype=torch.bool).reshape(())
+            cond_tensor = torch.where(drop_audio_cond_flag, torch.zeros_like(cond_tensor), cond_tensor)
+        elif drop_audio_cond:  # cfg for cond audio
+            cond_tensor = torch.zeros_like(cond_tensor)
 
-        x = self.proj(torch.cat((x, cond, text_embed), dim=-1))
-        x = self.conv_pos_embed(x, mask=audio_mask) + x
-        return x
+        x_tensor = self.proj(torch.cat((x_tensor, cond_tensor, text_embed_tensor), dim=-1))
+        x_tensor = self.conv_pos_embed(x_tensor, mask=audio_mask) + x_tensor
+        return x_tensor
 
 
 # Transformer backbone using DiT blocks
 
 
 class DiT(nn.Module):
+    supports_tensor_cfg_training_flags = True
+
     def __init__(
         self,
         *,
@@ -232,6 +255,14 @@ class DiT(nn.Module):
 
         self.checkpoint_activations = checkpoint_activations
 
+        # Optional regional torch.compile state. These attributes intentionally stay out
+        # of nn.Module registration so checkpoint/state_dict keys are unchanged. Compiled
+        # per-block callables live only on the owning DiT and are stripped on
+        # deepcopy/pickle (see __getstate__/__setstate__) so copies deserialize eager and
+        # never share the source model's compiled closures or parameters.
+        object.__setattr__(self, "_dit_compile_target", None)
+        object.__setattr__(self, "_compiled_dit_block_forwards", None)
+
         self.initialize_weights()
 
     # `_cache_local` is lazily initialized on first inference-time cache write so that
@@ -281,6 +312,117 @@ class DiT(nn.Module):
 
         return ckpt_forward
 
+    @property
+    def training_compile_state(self):
+        return {
+            "enabled": self._dit_compile_target is not None,
+            "target": self._dit_compile_target,
+        }
+
+    # Compile-only state must not survive deepcopy/pickle: compiled callables are bound to
+    # the source model's parameters and are unpickleable (torch.compile internals). Copies
+    # and deserialized models must fall back to eager execution rather than silently share
+    # the source closure or crash on pickle. This mirrors nn.Module's own handling of
+    # ``_compiled_call_impl`` in __getstate__.
+    _DIT_COMPILE_ONLY_ATTRS = ("_dit_compile_target", "_compiled_dit_block_forwards")
+
+    def __getstate__(self):
+        # Match nn.Module.__getstate__ on newer PyTorch releases without relying on
+        # that method: torch 2.0 lacks it, while Python 3.10's object also provides no
+        # parent implementation. Explicitly stripping PyTorch's compiled call hook
+        # preserves the behavior of torch 2.1+.
+        state = self.__dict__.copy()
+        state.pop("_compiled_call_impl", None)
+        for attr in self._DIT_COMPILE_ONLY_ATTRS:
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        for attr in self._DIT_COMPILE_ONLY_ATTRS:
+            object.__setattr__(self, attr, None)
+
+    def compile_training_target(self, target: str, **compile_kwargs):
+        """Compile a regional DiT training target without changing module ownership.
+
+        ``target='dit_blocks'`` compiles each existing ``DiTBlock``'s hook-aware
+        ``_call_impl`` and stores the compiled callables on the owning DiT. The
+        ``ModuleList`` and parameter registration remain unchanged, avoiding ``_orig_mod``
+        checkpoint keys and preserving Accelerate/DDP ownership. No ``block.forward`` is
+        patched, so deep copies, ``torch.save``, and multiprocessing spawn see ordinary
+        pickleable modules and deserialize to eager execution. Compiling ``_call_impl``
+        (the same mechanism ``nn.Module.compile`` uses) rather than the bare ``forward``
+        preserves forward pre/post hooks and full backward hooks exactly as in eager mode,
+        because ``_call_impl`` is nn.Module's hook-dispatch path.
+        """
+        if target != "dit_blocks":
+            raise ValueError("DiT regional compile target must be 'dit_blocks'")
+        if self.checkpoint_activations:
+            raise ValueError(
+                "torch.compile target=dit_blocks is incompatible with "
+                "DiT checkpoint_activations=True; disable activation checkpointing "
+                "or use target=cfm_loss_core."
+            )
+
+        self.clear_training_compile()
+        compiled = self._compile_each_dit_block(**compile_kwargs)
+        object.__setattr__(self, "_dit_compile_target", target)
+        return compiled
+
+    def clear_training_compile(self):
+        """Restore eager DiT execution after regional compilation."""
+        object.__setattr__(self, "_dit_compile_target", None)
+        object.__setattr__(self, "_compiled_dit_block_forwards", None)
+
+    def _compile_each_dit_block(self, **compile_kwargs):
+        # Compile each block's ``_call_impl`` rather than its bare ``forward``. ``_call_impl``
+        # is nn.Module's hook-aware dispatch: it runs forward pre/post hooks and wires full
+        # backward hooks (via BackwardHook) around ``forward``. Compiling it -- the same
+        # mechanism ``nn.Module.compile`` uses -- lets the owner-loop dispatch route through
+        # the compiled callable while preserving module hooks exactly as in eager mode.
+        # Compiling the bare ``forward`` instead would bypass ``_call_impl`` and silently
+        # drop every registered hook. ``block._compiled_call_impl`` is intentionally NOT set
+        # so eval/inference ``block(...)`` calls (which skip this training-gated dispatch)
+        # stay eager and never consume the training compile cache. Compile every block
+        # first; only commit the tuple to instance state once the whole list succeeds, so a
+        # partial failure leaves no compiled state behind.
+        compiled_forwards = tuple(
+            torch.compile(block._call_impl, **compile_kwargs) for block in self.transformer_blocks
+        )
+        object.__setattr__(self, "_compiled_dit_block_forwards", compiled_forwards)
+        return compiled_forwards
+
+    def _forward_block_range(self, x, t, mask, rope):
+        for block in self.transformer_blocks:
+            x = block(x, t, mask=mask, rope=rope)
+        return x
+
+    def _run_transformer_blocks(self, x, t, mask, rope):
+        if self.checkpoint_activations:
+            for block in self.transformer_blocks:
+                # https://pytorch.org/docs/stable/checkpoint.html#torch.utils.checkpoint.checkpoint
+                x = torch.utils.checkpoint.checkpoint(self.ckpt_wrapper(block), x, t, mask, rope, use_reentrant=False)
+            return x
+
+        # Regional compile dispatch: route through the compiled per-block callables only
+        # while training. Each callable is a compiled ``block._call_impl``, so calling it
+        # fires forward pre/post hooks and full backward hooks exactly as an eager
+        # ``block(...)`` would -- the compiled graph includes nn.Module's hook-dispatch
+        # path, not just the bare forward. Inference (CFM.sample, logged samples) uses the
+        # eager path so its distinct shapes (cfg_infer-doubled batch, swept durations)
+        # never consume the training compile cache's per-code-object recompile budget, and
+        # because ``block._compiled_call_impl`` is never set, an eager ``block(...)`` never
+        # accidentally enters the compiled path. Dispatch lives in the owner loop rather
+        # than on each block.forward so modules stay unpatched, deepcopy-safe, and
+        # pickleable.
+        compiled = self.__dict__.get("_compiled_dit_block_forwards")
+        if compiled is not None and self.training:
+            for compiled_forward in compiled:
+                x = compiled_forward(x, t, mask=mask, rope=rope)
+            return x
+
+        return self._forward_block_range(x, t, mask, rope)
+
     def get_input_embed(
         self,
         x,  # b n d
@@ -294,9 +436,11 @@ class DiT(nn.Module):
         if self.text_uncond is None or self.text_cond is None or not cache:
             if audio_mask is None:
                 seq_len = x.shape[1]
+                valid_seq_lens = None
             else:
-                seq_len = audio_mask.sum(dim=1)  # per-sample valid speech length
-            text_embed = self.text_embed(text, seq_len=seq_len, drop_text=drop_text)
+                seq_len = x.shape[1]
+                valid_seq_lens = audio_mask.sum(dim=1)  # per-sample valid speech length
+            text_embed = self.text_embed(text, seq_len=seq_len, drop_text=drop_text, valid_seq_lens=valid_seq_lens)
             if cache:
                 if drop_text:
                     self.text_uncond = text_embed
@@ -354,12 +498,7 @@ class DiT(nn.Module):
         if self.long_skip_connection is not None:
             residual = x
 
-        for block in self.transformer_blocks:
-            if self.checkpoint_activations:
-                # https://pytorch.org/docs/stable/checkpoint.html#torch.utils.checkpoint.checkpoint
-                x = torch.utils.checkpoint.checkpoint(self.ckpt_wrapper(block), x, t, mask, rope, use_reentrant=False)
-            else:
-                x = block(x, t, mask=mask, rope=rope)
+        x = self._run_transformer_blocks(x, t, mask, rope)
 
         if self.long_skip_connection is not None:
             x = self.long_skip_connection(torch.cat((x, residual), dim=-1))

--- a/src/f5_tts/model/backbones/mmdit.py
+++ b/src/f5_tts/model/backbones/mmdit.py
@@ -163,6 +163,19 @@ class MMDiT(nn.Module):
     def text_uncond(self, value):
         self._get_cache_local().text_uncond = value
 
+    _MMDIT_EPHEMERAL_ATTRS = ("_cache_local",)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for attr in self._MMDIT_EPHEMERAL_ATTRS:
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        for attr in self._MMDIT_EPHEMERAL_ATTRS:
+            object.__setattr__(self, attr, None)
+
     def initialize_weights(self):
         # Zero-out AdaLN layers in MMDiT blocks:
         for block in self.transformer_blocks:

--- a/src/f5_tts/model/backbones/unett.py
+++ b/src/f5_tts/model/backbones/unett.py
@@ -11,7 +11,7 @@ d - dimension
 from __future__ import annotations
 
 import threading
-from typing import Literal
+from typing import Literal, cast
 
 import torch
 import torch.nn.functional as F
@@ -52,17 +52,21 @@ class TextEmbedding(nn.Module):
             self.extra_modeling = False
 
     def forward(self, text: int["b nt"], seq_len, drop_text=False):
-        text = text + 1  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
-        text = text[:, :seq_len]  # curtail if character tokens are more than the mel spec tokens
-        batch, text_len = text.shape[0], text.shape[1]
-        text = F.pad(text, (0, seq_len - text_len), value=0)
-        if self.mask_padding:
-            text_mask = text == 0
+        text_tensor = (
+            cast(torch.Tensor, text) + 1
+        )  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
+        text_tensor = text_tensor[:, :seq_len]  # curtail if character tokens are more than the mel spec tokens
+        batch, text_len = text_tensor.shape[0], text_tensor.shape[1]
+        text_tensor = F.pad(text_tensor, (0, seq_len - text_len), value=0)
+        text_mask = text_tensor == 0
 
-        if drop_text:  # cfg for text
-            text = torch.zeros_like(text)
+        if torch.is_tensor(drop_text):
+            drop_text_flag = drop_text.to(device=text_tensor.device, dtype=torch.bool).reshape(())
+            text_tensor = torch.where(drop_text_flag, torch.zeros_like(text_tensor), text_tensor)
+        elif drop_text:  # cfg for text
+            text_tensor = torch.zeros_like(text_tensor)
 
-        text = self.text_embed(text)  # b n -> b n d
+        text_tensor = self.text_embed(text_tensor)  # b n -> b n d
 
         # possible extra modeling
         if self.extra_modeling:
@@ -70,18 +74,20 @@ class TextEmbedding(nn.Module):
             batch_start = torch.zeros((batch,), dtype=torch.long)
             pos_idx = get_pos_embed_indices(batch_start, seq_len, max_pos=self.precompute_max_pos)
             text_pos_embed = self.freqs_cis[pos_idx]
-            text = text + text_pos_embed
+            text_tensor = text_tensor + text_pos_embed
 
             # convnextv2 blocks
             if self.mask_padding:
-                text = text.masked_fill(text_mask.unsqueeze(-1).expand(-1, -1, text.size(-1)), 0.0)
+                text_tensor = text_tensor.masked_fill(text_mask.unsqueeze(-1).expand(-1, -1, text_tensor.size(-1)), 0.0)
                 for block in self.text_blocks:
-                    text = block(text)
-                    text = text.masked_fill(text_mask.unsqueeze(-1).expand(-1, -1, text.size(-1)), 0.0)
+                    text_tensor = block(text_tensor)
+                    text_tensor = text_tensor.masked_fill(
+                        text_mask.unsqueeze(-1).expand(-1, -1, text_tensor.size(-1)), 0.0
+                    )
             else:
-                text = self.text_blocks(text)
+                text_tensor = self.text_blocks(text_tensor)
 
-        return text
+        return text_tensor
 
 
 # noised input audio and context mixing embedding
@@ -94,18 +100,26 @@ class InputEmbedding(nn.Module):
         self.conv_pos_embed = ConvPositionEmbedding(dim=out_dim)
 
     def forward(self, x: float["b n d"], cond: float["b n d"], text_embed: float["b n d"], drop_audio_cond=False):
-        if drop_audio_cond:  # cfg for cond audio
-            cond = torch.zeros_like(cond)
+        x_tensor = cast(torch.Tensor, x)
+        cond_tensor = cast(torch.Tensor, cond)
+        text_embed_tensor = cast(torch.Tensor, text_embed)
+        if torch.is_tensor(drop_audio_cond):
+            drop_audio_cond_flag = drop_audio_cond.to(device=cond_tensor.device, dtype=torch.bool).reshape(())
+            cond_tensor = torch.where(drop_audio_cond_flag, torch.zeros_like(cond_tensor), cond_tensor)
+        elif drop_audio_cond:  # cfg for cond audio
+            cond_tensor = torch.zeros_like(cond_tensor)
 
-        x = self.proj(torch.cat((x, cond, text_embed), dim=-1))
-        x = self.conv_pos_embed(x) + x
-        return x
+        x_tensor = self.proj(torch.cat((x_tensor, cond_tensor, text_embed_tensor), dim=-1))
+        x_tensor = self.conv_pos_embed(x_tensor) + x_tensor
+        return x_tensor
 
 
 # Flat UNet Transformer backbone
 
 
 class UNetT(nn.Module):
+    supports_tensor_cfg_training_flags = True
+
     def __init__(
         self,
         *,

--- a/src/f5_tts/model/backbones/unett.py
+++ b/src/f5_tts/model/backbones/unett.py
@@ -226,6 +226,20 @@ class UNetT(nn.Module):
     def text_uncond(self, value):
         self._get_cache_local().text_uncond = value
 
+    _UNETT_EPHEMERAL_ATTRS = ("_cache_local",)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop("_compiled_call_impl", None)
+        for attr in self._UNETT_EPHEMERAL_ATTRS:
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        for attr in self._UNETT_EPHEMERAL_ATTRS:
+            object.__setattr__(self, attr, None)
+
     def get_input_embed(
         self,
         x,  # b n d

--- a/src/f5_tts/model/cfm.py
+++ b/src/f5_tts/model/cfm.py
@@ -31,6 +31,77 @@ from f5_tts.model.utils import (
 )
 
 
+TRAINING_COMPILE_TARGETS = ("cfm_loss_core", "dit_blocks")
+
+
+def _is_cuda_oom(exc: BaseException) -> bool:
+    """Return True only for a genuine CUDA allocator out-of-memory error.
+
+    Both checks require the message to mention CUDA. ``torch.cuda.OutOfMemoryError``
+    is an alias of the generic ``torch.OutOfMemoryError`` in current PyTorch, so the
+    type alone also matches host/CPU allocator failures. And a bare ``"out of memory"``
+    substring match would misclassify compiler-side failures (for example a Triton
+    autotune worker reporting *host* OOM) as a GPU capacity problem, hard-failing a run
+    that should have fallen back to eager.
+    """
+    oom_type = getattr(torch.cuda, "OutOfMemoryError", None)
+    if oom_type is not None and isinstance(exc, oom_type):
+        return "cuda" in str(exc).lower()
+    if isinstance(exc, RuntimeError):
+        message = str(exc).lower()
+        return "out of memory" in message and "cuda" in message
+    return False
+
+
+def _note_oom_compile_context(exc: BaseException) -> None:
+    """Attach a compile-context note to a CUDA OOM without changing its type/message.
+
+    ``add_note`` (Python 3.11+) appends to ``__notes__`` and is not part of
+    ``str(exc)``, so ``except`` type checks and message-based batch-size reducers
+    keep matching the original exception. Idempotent: never duplicates the note.
+    """
+    note = "torch.compile: GPU OOM; not falling back to eager (reduce batch size / sequence length)."
+    add_note = getattr(exc, "add_note", None)
+    if add_note is None:
+        return
+    existing = getattr(exc, "__notes__", None) or ()
+    if note in existing:
+        return
+    add_note(note)
+
+
+def _compile_failure_types() -> tuple[type[BaseException], ...]:
+    """Exception types that mean 'the compiler failed', not 'the model is wrong'.
+
+    Only these justify an eager retry. A compiler failure is raised while Dynamo is
+    tracing or while the backend is lowering, i.e. *before* the graph executes, so a
+    retry cannot double-apply side effects. Ordinary model errors (shape mismatch, bad
+    vocabulary index, dtype error, assertion) must propagate unchanged: swallowing them
+    would hide a real bug behind a misleading "compile fallback" message and then raise
+    a second, more confusing error from the eager retry.
+    """
+    types: list[type[BaseException]] = []
+    try:
+        from torch._dynamo import exc as dynamo_exc
+
+        for name in ("BackendCompilerFailed", "Unsupported", "InternalTorchDynamoError", "TorchRuntimeError"):
+            candidate = getattr(dynamo_exc, name, None)
+            if isinstance(candidate, type) and issubclass(candidate, BaseException):
+                types.append(candidate)
+    except Exception:  # pragma: no cover - torch without _dynamo
+        pass
+    try:
+        from torch._inductor import exc as inductor_exc
+
+        for name in ("InductorError", "CppCompileError", "CUDACompileError"):
+            candidate = getattr(inductor_exc, name, None)
+            if isinstance(candidate, type) and issubclass(candidate, BaseException):
+                types.append(candidate)
+    except Exception:  # pragma: no cover - torch without _inductor
+        pass
+    return tuple(types)
+
+
 class CFM(nn.Module):
     def __init__(
         self,
@@ -76,9 +147,360 @@ class CFM(nn.Module):
         # vocab map for tokenization
         self.vocab_char_map = vocab_char_map
 
+        # torch.compile state for optional training targets. object.__setattr__ bypasses
+        # nn.Module.__setattr__ so these are never registered as parameters/buffers;
+        # state_dict is unchanged and EMA deepcopy (which runs before any compile call)
+        # never sees a compiled callable.
+        object.__setattr__(self, "_compiled_loss_core", None)
+        object.__setattr__(self, "_compile_target", None)
+        object.__setattr__(self, "_compile_runtime_fallback", True)
+        object.__setattr__(self, "_compile_fallback_active", False)
+        object.__setattr__(self, "_compile_error", None)
+
+    # torch.compile returns Python callables that close over this exact CFM instance.
+    # deepcopy treats functions as atomic, so copying a compiled CFM without stripping
+    # this state would leave the copy executing the source model's parameters. The same
+    # wrapper is not pickleable as part of a whole-model torch.save. Copies and loaded
+    # models therefore intentionally resume eager, matching the regional DiT policy.
+    _CFM_COMPILE_ONLY_ATTRS = (
+        "_compiled_loss_core",
+        "_compile_target",
+        "_compile_runtime_fallback",
+        "_compile_fallback_active",
+        "_compile_error",
+    )
+
+    def __getstate__(self):
+        # Match nn.Module.__getstate__ on newer PyTorch releases without relying on
+        # that method: torch 2.0 lacks it, while Python 3.10's object also provides no
+        # parent implementation. Explicitly stripping PyTorch's compiled call hook
+        # preserves the behavior of torch 2.1+.
+        state = self.__dict__.copy()
+        state.pop("_compiled_call_impl", None)
+        for attr in self._CFM_COMPILE_ONLY_ATTRS:
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        object.__setattr__(self, "_compiled_loss_core", None)
+        object.__setattr__(self, "_compile_target", None)
+        object.__setattr__(self, "_compile_runtime_fallback", True)
+        object.__setattr__(self, "_compile_fallback_active", False)
+        object.__setattr__(self, "_compile_error", None)
+
     @property
     def device(self):
         return next(self.parameters()).device
+
+    @property
+    def training_compile_state(self):
+        enabled = self._training_compile_enabled()
+        return {
+            "enabled": enabled,
+            "target": self._compile_target if enabled else None,
+            "fallback_active": self._compile_fallback_active,
+            "error": self._compile_error,
+        }
+
+    def compile_training_core(self, *, target: str = "cfm_loss_core", runtime_fallback: bool = True, **compile_kwargs):
+        """Compile an explicit training target for an optional speedup.
+
+        ``target=cfm_loss_core`` preserves the original behavior: only the deterministic
+        core (xt interpolation, transformer forward, masked MSE) is compiled; stochastic
+        preparation (mel extraction, span masking, noise/time sampling, CFG dropout) stays
+        eager in ``forward`` so RNG state is unaffected.
+
+        ``target=dit_blocks`` compiles each repeated DiT block independently and leaves
+        embeddings, rotary setup, final projection, and loss reduction eager. This regional
+        target is useful for variable-length training where the larger CFM loss-core graph
+        has excessive cold compile/recompile overhead.
+
+        ``runtime_fallback`` (default True) lets a *forward* compile failure permanently
+        switch this module to eager. Set it False under DDP so a failure raises on every
+        rank instead of desynchronising the gradient all-reduce. Note: this fallback
+        covers forward failures only; a compile failure during backward is not caught and
+        will raise. To surface such errors, set ``runtime_fallback=False`` (Trainer:
+        ``compile_fallback_to_eager=False``) so a compile failure raises instead of
+        silently switching to eager; compilation itself stays active.
+        """
+        if target not in TRAINING_COMPILE_TARGETS:
+            valid = ", ".join(TRAINING_COMPILE_TARGETS)
+            raise ValueError(f"Unknown torch.compile training target {target!r}; expected one of: {valid}")
+
+        self.clear_training_compile()
+
+        if target == "cfm_loss_core":
+            self._check_compile_compatible_transformer(target=target)
+            compiled = torch.compile(self._forward_loss_core_components, **compile_kwargs)
+            object.__setattr__(self, "_compiled_loss_core", compiled)
+        else:
+            compile_fn = getattr(self.transformer, "compile_training_target", None)
+            if compile_fn is None:
+                raise ValueError(
+                    "torch.compile target='dit_blocks' requires a DiT transformer exposing "
+                    "compile_training_target(); use target='cfm_loss_core' for other backbones."
+                )
+            compiled = compile_fn(target, **compile_kwargs)
+
+        object.__setattr__(self, "_compile_target", target)
+        object.__setattr__(self, "_compile_runtime_fallback", bool(runtime_fallback))
+        object.__setattr__(self, "_compile_fallback_active", False)
+        object.__setattr__(self, "_compile_error", None)
+        return compiled
+
+    def clear_training_compile(self):
+        """Remove any compiled training target, reverting to eager execution."""
+        clear_transformer = getattr(self.transformer, "clear_training_compile", None)
+        if clear_transformer is not None:
+            clear_transformer()
+        object.__setattr__(self, "_compiled_loss_core", None)
+        object.__setattr__(self, "_compile_target", None)
+        object.__setattr__(self, "_compile_runtime_fallback", True)
+        object.__setattr__(self, "_compile_fallback_active", False)
+        object.__setattr__(self, "_compile_error", None)
+
+    def _transformer_training_compile_state(self):
+        state = getattr(self.transformer, "training_compile_state", None)
+        if state is None:
+            return {"enabled": False}
+        return state
+
+    def _training_compile_enabled(self):
+        return self._compiled_loss_core is not None or bool(
+            self._transformer_training_compile_state().get("enabled", False)
+        )
+
+    def _check_compile_compatible_transformer(self, *, target: str):
+        """Reject transformer paths known to graph-break inside compiled training.
+
+        DiT's ``text_embedding_average_upsampling=True`` calls
+        ``average_upsample_text_by_mask`` from the compiled loss core. That path
+        contains a per-sample Python loop plus ``Tensor.item()`` calls, which graph-break
+        under torch.compile and hard-fail with ``fullgraph=True``. Failing at setup gives
+        Trainer a clean eager fallback path instead of a late Dynamo error.
+        """
+        if target != "cfm_loss_core":
+            return
+
+        text_embed = getattr(self.transformer, "text_embed", None)
+        if text_embed is not None and getattr(text_embed, "average_upsampling", False):
+            raise ValueError(
+                "torch.compile training is incompatible with "
+                "DiT text_embedding_average_upsampling=True: the per-sample "
+                "average_upsample_text_by_mask loop uses Tensor.item() and breaks "
+                "the compiled graph. Disable compile (fallback_to_eager=True) or set "
+                "text_embedding_average_upsampling=False to enable compiled training."
+            )
+
+    def _run_loss_core_components(self, *args):
+        """Run the deterministic loss core via the compiled callable, with eager fallback.
+
+        No RNG save/restore: the stochastic inputs (x0, time, rand_span_mask, drop_*) are
+        already materialised in ``args`` before this call, so an eager retry reuses them
+        exactly. The only RNG inside the compiled region is nn.Dropout in the transformer;
+        torch.get_rng_state does not round-trip the Philox offset used by compiled code, so
+        restoring it would give a false guarantee. A fresh dropout draw on fallback is valid.
+
+        Only *compiler* failures trigger the eager retry (see ``_compile_failure_types``).
+        Ordinary model errors propagate unchanged so a genuine bug is not disguised as a
+        compile problem and then re-raised from a second, partially-executed forward.
+        """
+        compiled = self.__dict__.get("_compiled_loss_core")
+        compiled_active = self._training_compile_enabled()
+        if not compiled_active:
+            return self._forward_loss_core_components(*args)
+        try:
+            if compiled is not None:
+                return compiled(*args)
+            # Regional DiT targets execute through the eager loss-core path; the DiT
+            # blocks invoked from the transformer are the compiled callables.
+            return self._forward_loss_core_components(*args)
+        except Exception as exc:
+            # A compiled CUDA OOM is a capacity failure, not a compiler failure.
+            # Retrying eagerly usually repeats the same allocation pressure and can hide
+            # the real problem behind a fallback state, so never fall back on a real GPU
+            # OOM. Re-raise the ORIGINAL exception (bare ``raise``) so its concrete type
+            # (``torch.cuda.OutOfMemoryError``) and the standard ``CUDA out of memory``
+            # message survive: ``except torch.cuda.OutOfMemoryError`` handlers and
+            # message-based batch-size reducers depend on them. A note adds compile
+            # context without altering type or message matching.
+            if _is_cuda_oom(exc):
+                _note_oom_compile_context(exc)
+                raise
+            if not self._compile_runtime_fallback:
+                raise
+            if not isinstance(exc, _compile_failure_types()):
+                raise
+            # Permanently disable compile for the rest of this run.
+            self.clear_training_compile()
+            object.__setattr__(self, "_compile_fallback_active", True)
+            object.__setattr__(self, "_compile_error", repr(exc))
+            return self._forward_loss_core_components(*args)
+
+    def _run_loss_core(self, *args):
+        """Run the loss core and preserve the public training return shape.
+
+        With compile disabled this dispatches to the bit-exact upstream reduction so the
+        default training path is byte-identical to F5-TTS without this feature. The
+        compile-friendly reduction is algebraically identical but reassociates the sum,
+        which changes the result by ~1 ULP -- acceptable for an opt-in speedup, not
+        acceptable for users who never asked for it.
+
+        After a *runtime compile fallback* (``_compile_fallback_active``), the module is
+        back to eager, but we deliberately keep the fp32 masked-multiply reduction
+        (``_forward_loss_core_components``) instead of the upstream-exact path. The
+        upstream path computes ``F.mse_loss(pred, flow)`` in the input dtype, so an fp16
+        AMP run that fell back mid-training would switch from the compiled fp32
+        accumulation to fp16 squared error and could turn a finite loss into ``inf``/
+        ``nan``. The fp32 components path is numerically safe and matches the reduction
+        the run was using while compiled. The never-compiled default (``_compile_fallback_
+        active`` stays False) still takes the byte-exact upstream path.
+        """
+        if not self._training_compile_enabled():
+            if self._compile_fallback_active:
+                loss, _, _, cond, pred = self._forward_loss_core_components(*args)
+                return loss, cond, pred
+            return self._forward_loss_core_upstream_exact(*args)
+        loss, _, _, cond, pred = self._run_loss_core_components(*args)
+        return loss, cond, pred
+
+    def _forward_loss_core_upstream_exact(
+        self,
+        x1: torch.Tensor,
+        text: torch.Tensor,
+        mask: torch.Tensor,
+        rand_span_mask: torch.Tensor,
+        x0: torch.Tensor,
+        time: torch.Tensor,
+        drop_audio_cond: bool | torch.Tensor,
+        drop_text: bool | torch.Tensor,
+    ):
+        """Reproduce upstream's loss reduction exactly (never compiled).
+
+        ``loss[rand_span_mask]`` produces a data-dependent shape, which graph-breaks under
+        torch.compile -- that is precisely why the compiled path uses the masked-multiply
+        form instead. Keeping this expression for the default path is what makes
+        compile-disabled training bit-for-bit identical to upstream, including dtype: the
+        compiled path accumulates in fp32 (needed so a raw ``loss_sum`` cannot overflow
+        fp16), whereas upstream returns the input dtype.
+        """
+        t = time.unsqueeze(-1).unsqueeze(-1)
+        φ = (1 - t) * x0 + t * x1
+        flow = x1 - x0
+
+        cond = torch.where(rand_span_mask[..., None], torch.zeros_like(x1), x1)
+
+        pred = self.transformer(
+            x=φ, cond=cond, text=text, time=time, drop_audio_cond=drop_audio_cond, drop_text=drop_text, mask=mask
+        )
+
+        loss = F.mse_loss(pred, flow, reduction="none")
+        loss = loss[rand_span_mask]
+
+        return loss.mean(), cond, pred
+
+    def _prepare_training_inputs(self, inp, text, lens):
+        """Stochastic preparation shared by ``forward`` (stays eager; not compiled)."""
+        # handle raw wave
+        if inp.ndim == 2:
+            inp = self.mel_spec(inp)
+            inp = inp.permute(0, 2, 1)
+            assert inp.shape[-1] == self.num_channels
+
+        batch, seq_len, dtype, device = *inp.shape[:2], inp.dtype, self.device
+
+        # handle text as string
+        if isinstance(text, list):
+            if exists(self.vocab_char_map):
+                text = list_str_to_idx(text, self.vocab_char_map).to(device)
+            else:
+                text = list_str_to_tensor(text).to(device)
+            assert text.shape[0] == batch
+
+        # lens and mask: long dtype for mask index arithmetic
+        if not exists(lens):  # if lens not acquired by trainer from collate_fn
+            lens = torch.full((batch,), seq_len, device=device, dtype=torch.long)
+        else:
+            lens = lens.to(device=device, dtype=torch.long)
+        mask = lens_to_mask(lens, length=seq_len)
+
+        # get a random span to mask out for training conditionally
+        frac_lengths = torch.zeros((batch,), device=self.device).float().uniform_(*self.frac_lengths_mask)
+        rand_span_mask = mask_from_frac_lengths(lens, frac_lengths, length=seq_len)
+
+        if exists(mask):
+            rand_span_mask &= mask
+
+        # mel is x1; x0 is gaussian noise; time step
+        x1 = inp
+        x0 = torch.randn_like(x1)
+        time = torch.rand((batch,), dtype=dtype, device=self.device)
+        # TODO. noise_scheduler
+
+        # transformer and cfg training with a drop rate
+        drop_audio_cond = random() < self.audio_drop_prob  # p_drop in voicebox paper
+        if random() < self.cond_drop_prob:  # p_uncond in voicebox paper
+            drop_audio_cond = True
+            drop_text = True
+        else:
+            drop_text = False
+
+        # Tensor-aware backbones consume CFG flags with branchless embedding masks.
+        # Keeping these flags as 0-D tensors avoids separate torch.compile graphs for
+        # each CFG bool combination while preserving the same sampled drop decisions.
+        # Tensorize only when a compile target is actually active so the never-compiled
+        # default path stays byte-identical to upstream (Python bools, zero allocation
+        # on no-drop steps). Runtime fallback clears compile state, so flags revert to
+        # bools automatically. Backbones without this capability keep historical bools.
+        if getattr(self.transformer, "supports_tensor_cfg_training_flags", False) and self._training_compile_enabled():
+            drop_audio_cond = torch.as_tensor(drop_audio_cond, device=device, dtype=torch.bool)
+            drop_text = torch.as_tensor(drop_text, device=device, dtype=torch.bool)
+
+        return x1, text, mask, rand_span_mask, x0, time, drop_audio_cond, drop_text
+
+    def _forward_loss_core_components(
+        self,
+        x1: torch.Tensor,
+        text: torch.Tensor,
+        mask: torch.Tensor,
+        rand_span_mask: torch.Tensor,
+        x0: torch.Tensor,
+        time: torch.Tensor,
+        drop_audio_cond: bool | torch.Tensor,
+        drop_text: bool | torch.Tensor,
+    ):
+        # Deterministic loss core: sample xt (φ_t(x) in the paper)
+        t = time.unsqueeze(-1).unsqueeze(-1)
+        φ = (1 - t) * x0 + t * x1
+        flow = x1 - x0
+
+        # only predict what is within the random mask span for infilling
+        cond = torch.where(rand_span_mask[..., None], torch.zeros_like(x1), x1)
+
+        # apply mask will use more memory; might adjust batchsize or batchsampler long sequence threshold
+        pred = self.transformer(
+            x=φ, cond=cond, text=text, time=time, drop_audio_cond=drop_audio_cond, drop_text=drop_text, mask=mask
+        )
+
+        # flow matching loss: masked mean over valid span tokens and feature dim.
+        # Boolean indexing (loss[rand_span_mask]) causes a graph break under torch.compile;
+        # the elementwise multiply form is numerically equivalent and compile-friendly.
+        # denom.clamp(min=1.0) keeps the loss finite when no token is selected.
+        # Accumulate the squared error in fp32 so fp16 AMP/global loss-sum
+        # training cannot overflow before GradScaler sees the loss.
+        loss = F.mse_loss(pred.float(), flow.float(), reduction="none")
+        loss_mask = rand_span_mask[..., None].to(loss.dtype)
+        loss_sum = (loss * loss_mask).sum()
+        denom = (loss_mask.sum() * loss.shape[-1]).clamp(min=1.0)
+        loss = loss_sum / denom
+
+        return loss, loss_sum, denom, cond, pred
+
+    def _forward_loss_core(self, *args):
+        """Return the historical mean-loss tuple for callers outside the trainer."""
+        loss, _, _, cond, pred = self._forward_loss_core_components(*args)
+        return loss, cond, pred
 
     @torch.no_grad()
     def sample(
@@ -236,67 +658,9 @@ class CFM(nn.Module):
         lens: int["b"] | None = None,
         noise_scheduler: str | None = None,
     ):
-        # handle raw wave
-        if inp.ndim == 2:
-            inp = self.mel_spec(inp)
-            inp = inp.permute(0, 2, 1)
-            assert inp.shape[-1] == self.num_channels
-
-        batch, seq_len, dtype, device, _σ1 = *inp.shape[:2], inp.dtype, self.device, self.sigma
-
-        # handle text as string
-        if isinstance(text, list):
-            if exists(self.vocab_char_map):
-                text = list_str_to_idx(text, self.vocab_char_map).to(device)
-            else:
-                text = list_str_to_tensor(text).to(device)
-            assert text.shape[0] == batch
-
-        # lens and mask
-        if not exists(lens):  # if lens not acquired by trainer from collate_fn
-            lens = torch.full((batch,), seq_len, device=device)
-        mask = lens_to_mask(lens, length=seq_len)
-
-        # get a random span to mask out for training conditionally
-        frac_lengths = torch.zeros((batch,), device=self.device).float().uniform_(*self.frac_lengths_mask)
-        rand_span_mask = mask_from_frac_lengths(lens, frac_lengths)
-
-        if exists(mask):
-            rand_span_mask &= mask
-
-        # mel is x1
-        x1 = inp
-
-        # x0 is gaussian noise
-        x0 = torch.randn_like(x1)
-
-        # time step
-        time = torch.rand((batch,), dtype=dtype, device=self.device)
-        # TODO. noise_scheduler
-
-        # sample xt (φ_t(x) in the paper)
-        t = time.unsqueeze(-1).unsqueeze(-1)
-        φ = (1 - t) * x0 + t * x1
-        flow = x1 - x0
-
-        # only predict what is within the random mask span for infilling
-        cond = torch.where(rand_span_mask[..., None], torch.zeros_like(x1), x1)
-
-        # transformer and cfg training with a drop rate
-        drop_audio_cond = random() < self.audio_drop_prob  # p_drop in voicebox paper
-        if random() < self.cond_drop_prob:  # p_uncond in voicebox paper
-            drop_audio_cond = True
-            drop_text = True
-        else:
-            drop_text = False
-
-        # apply mask will use more memory; might adjust batchsize or batchsampler long sequence threshold
-        pred = self.transformer(
-            x=φ, cond=cond, text=text, time=time, drop_audio_cond=drop_audio_cond, drop_text=drop_text, mask=mask
+        # Stochastic preparation stays eager; deterministic loss core may be compiled.
+        x1, text, mask, rand_span_mask, x0, time, drop_audio_cond, drop_text = self._prepare_training_inputs(
+            inp, text, lens
         )
-
-        # flow matching loss
-        loss = F.mse_loss(pred, flow, reduction="none")
-        loss = loss[rand_span_mask]
-
-        return loss.mean(), cond, pred
+        loss, cond, pred = self._run_loss_core(x1, text, mask, rand_span_mask, x0, time, drop_audio_cond, drop_text)
+        return loss, cond, pred

--- a/src/f5_tts/model/cfm.py
+++ b/src/f5_tts/model/cfm.py
@@ -400,7 +400,33 @@ class CFM(nn.Module):
 
         return loss.mean(), cond, pred
 
-    def _prepare_training_inputs(self, inp, text, lens):
+    def sample_training_mask(self, lens: torch.Tensor, seq_len: int) -> torch.Tensor:
+        """Sample the random span mask used by one training forward.
+
+        ``global_masked_mean`` needs the exact masked-element count before any
+        backward pass in an accumulation window. Sampling the mask separately
+        keeps that preload lightweight: no transformer activations or autograd
+        graphs are retained while the window denominator is reduced.
+        """
+        if seq_len < 0:
+            raise ValueError(f"seq_len must be non-negative, but received {seq_len}")
+        if lens.ndim != 1:
+            raise ValueError(f"lens must be one-dimensional, but received shape {tuple(lens.shape)}")
+        if lens.dtype == torch.bool or lens.is_floating_point() or lens.is_complex():
+            raise TypeError(f"lens must use an integer dtype, but received {lens.dtype}")
+        if bool(((lens < 0) | (lens > seq_len)).any().item()):
+            raise ValueError(f"lens values must be between 0 and seq_len ({seq_len})")
+
+        lens = lens.to(device=self.device, dtype=torch.long)
+        valid_mask = lens_to_mask(lens, length=seq_len)
+        return self._sample_training_mask(lens, seq_len, valid_mask)
+
+    def _sample_training_mask(self, lens: torch.Tensor, seq_len: int, valid_mask: torch.Tensor) -> torch.Tensor:
+        frac_lengths = torch.zeros((lens.shape[0],), device=self.device).float().uniform_(*self.frac_lengths_mask)
+        rand_span_mask = mask_from_frac_lengths(lens, frac_lengths, length=seq_len)
+        return rand_span_mask & valid_mask
+
+    def _prepare_training_inputs(self, inp, text, lens, rand_span_mask: torch.Tensor | None = None):
         """Stochastic preparation shared by ``forward`` (stays eager; not compiled)."""
         # handle raw wave
         if inp.ndim == 2:
@@ -425,12 +451,21 @@ class CFM(nn.Module):
             lens = lens.to(device=device, dtype=torch.long)
         mask = lens_to_mask(lens, length=seq_len)
 
-        # get a random span to mask out for training conditionally
-        frac_lengths = torch.zeros((batch,), device=self.device).float().uniform_(*self.frac_lengths_mask)
-        rand_span_mask = mask_from_frac_lengths(lens, frac_lengths, length=seq_len)
-
-        if exists(mask):
-            rand_span_mask &= mask
+        # Get a random span to mask out for training conditionally. The global
+        # masked-mean trainer pre-samples this mask so it can normalize the
+        # whole accumulation window before backward; all other callers retain
+        # the historical in-forward sampling order.
+        if rand_span_mask is None:
+            rand_span_mask = self._sample_training_mask(lens, seq_len, mask)
+        else:
+            expected_shape = (batch, seq_len)
+            if tuple(rand_span_mask.shape) != expected_shape:
+                raise ValueError(
+                    f"rand_span_mask must have shape {expected_shape}, but received {tuple(rand_span_mask.shape)}"
+                )
+            if rand_span_mask.dtype != torch.bool:
+                raise TypeError(f"rand_span_mask must have dtype torch.bool, but received {rand_span_mask.dtype}")
+            rand_span_mask = rand_span_mask.to(device=device) & mask
 
         # mel is x1; x0 is gaussian noise; time step
         x1 = inp
@@ -657,10 +692,14 @@ class CFM(nn.Module):
         *,
         lens: int["b"] | None = None,
         noise_scheduler: str | None = None,
+        rand_span_mask: torch.Tensor | None = None,
+        return_loss_components: bool = False,
     ):
         # Stochastic preparation stays eager; deterministic loss core may be compiled.
         x1, text, mask, rand_span_mask, x0, time, drop_audio_cond, drop_text = self._prepare_training_inputs(
-            inp, text, lens
+            inp, text, lens, rand_span_mask
         )
+        if return_loss_components:
+            return self._run_loss_core_components(x1, text, mask, rand_span_mask, x0, time, drop_audio_cond, drop_text)
         loss, cond, pred = self._run_loss_core(x1, text, mask, rand_span_mask, x0, time, drop_audio_cond, drop_text)
         return loss, cond, pred

--- a/src/f5_tts/model/cfm.py
+++ b/src/f5_tts/model/cfm.py
@@ -84,7 +84,7 @@ def _compile_failure_types() -> tuple[type[BaseException], ...]:
     try:
         from torch._dynamo import exc as dynamo_exc
 
-        for name in ("BackendCompilerFailed", "Unsupported", "InternalTorchDynamoError", "TorchRuntimeError"):
+        for name in ("BackendCompilerFailed", "Unsupported", "InternalTorchDynamoError"):
             candidate = getattr(dynamo_exc, name, None)
             if isinstance(candidate, type) and issubclass(candidate, BaseException):
                 types.append(candidate)

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -279,13 +279,15 @@ class Trainer:
         else:
             generator = None
 
+        persistent_workers = num_workers > 0
+
         if self.batch_size_type == "sample":
             train_dataloader = DataLoader(
                 train_dataset,
                 collate_fn=collate_fn,
                 num_workers=num_workers,
                 pin_memory=True,
-                persistent_workers=True,
+                persistent_workers=persistent_workers,
                 batch_size=self.batch_size_per_gpu,
                 shuffle=True,
                 generator=generator,
@@ -305,7 +307,7 @@ class Trainer:
                 collate_fn=collate_fn,
                 num_workers=num_workers,
                 pin_memory=True,
-                persistent_workers=True,
+                persistent_workers=persistent_workers,
                 batch_sampler=batch_sampler,
             )
         else:

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -20,6 +20,14 @@ from f5_tts.model.dataset import DynamicBatchSampler, collate_fn
 from f5_tts.model.utils import default, exists
 
 
+try:
+    from torch.optim.optimizer import _get_fused_kernels_supported_devices as _fused_devices
+
+    FUSED_ADAMW_DEVICE_TYPES = frozenset(_fused_devices())
+except ImportError:
+    FUSED_ADAMW_DEVICE_TYPES = frozenset(("cuda", "cpu", "xpu", "privateuseone"))
+
+
 # trainer
 
 
@@ -140,7 +148,8 @@ class Trainer:
 
             self.optimizer = bnb.optim.AdamW8bit(model.parameters(), lr=learning_rate)
         else:
-            self.optimizer = AdamW(model.parameters(), lr=learning_rate, fused=True)
+            use_fused = self.accelerator.device.type in FUSED_ADAMW_DEVICE_TYPES
+            self.optimizer = AdamW(model.parameters(), lr=learning_rate, fused=use_fused)
         self.model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
 
     @property

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -925,11 +925,16 @@ class Trainer:
         # otherwise by default with split_batches=False, warmup steps change with num_processes
         total_updates = math.ceil(len(train_dataloader) / self.grad_accumulation_steps) * self.epochs
         decay_updates = total_updates - warmup_updates
-        warmup_scheduler = LinearLR(self.optimizer, start_factor=1e-8, end_factor=1.0, total_iters=warmup_updates)
         decay_scheduler = LinearLR(self.optimizer, start_factor=1.0, end_factor=1e-8, total_iters=decay_updates)
-        self.scheduler = SequentialLR(
-            self.optimizer, schedulers=[warmup_scheduler, decay_scheduler], milestones=[warmup_updates]
-        )
+        if warmup_updates > 0:
+            warmup_scheduler = LinearLR(self.optimizer, start_factor=1e-8, end_factor=1.0, total_iters=warmup_updates)
+            self.scheduler = SequentialLR(
+                self.optimizer, schedulers=[warmup_scheduler, decay_scheduler], milestones=[warmup_updates]
+            )
+        else:
+            # Torch 2.5 leaves the optimizer at the warmup start factor when a
+            # zero-length scheduler is included in SequentialLR.
+            self.scheduler = decay_scheduler
         if self.global_masked_mean:
             # Buffer accumulation windows on the host. A normally prepared
             # dataloader places each yielded batch on the accelerator, which

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -25,7 +25,7 @@ try:
 
     FUSED_ADAMW_DEVICE_TYPES = frozenset(_fused_devices())
 except ImportError:
-    FUSED_ADAMW_DEVICE_TYPES = frozenset(("cuda", "cpu", "xpu", "privateuseone"))
+    FUSED_ADAMW_DEVICE_TYPES = frozenset(("cuda",))
 
 
 # trainer

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import gc
 import inspect
 import math
+import operator
 import os
+import random
 from contextlib import contextmanager, nullcontext
 from typing import Any, cast
 
 import torch
+import torch.distributed as dist
 import torchaudio
 import wandb
 from accelerate import Accelerator
@@ -15,10 +18,11 @@ from accelerate.utils import DistributedDataParallelKwargs, DistributedType, sen
 from ema_pytorch import EMA
 from torch.optim import AdamW
 from torch.optim.lr_scheduler import LinearLR, SequentialLR
-from torch.utils.data import DataLoader, Dataset, SequentialSampler
+from torch.utils.data import DataLoader, Dataset, Sampler, SequentialSampler
 from tqdm import tqdm
 
 from f5_tts.model import CFM
+from f5_tts.model.cfm import _is_cuda_oom
 from f5_tts.model.dataset import DynamicBatchSampler, collate_fn
 from f5_tts.model.utils import default, exists
 
@@ -58,6 +62,27 @@ try:
     FUSED_ADAMW_DEVICE_TYPES = frozenset(_fused_devices())
 except ImportError:
     FUSED_ADAMW_DEVICE_TYPES = frozenset(("cuda",))
+
+
+class _EpochRandomSampler(Sampler[int]):
+    """Random sampler whose order is stable and addressable by epoch."""
+
+    def __init__(self, data_source, seed: int):
+        self.data_source = data_source
+        self.seed = int(seed)
+        self.epoch = 0
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + self.epoch)
+        indices = torch.randperm(len(self.data_source), generator=generator).tolist()
+        return iter(indices)
+
+    def __len__(self):
+        return len(self.data_source)
+
+    def set_epoch(self, epoch: int):
+        self.epoch = int(epoch)
 
 
 # trainer
@@ -102,6 +127,7 @@ class Trainer:
         compile_fallback_to_eager: bool = True,
         global_masked_mean: bool = False,
     ):
+        grad_accumulation_steps = self._validate_gradient_accumulation_steps(grad_accumulation_steps)
         ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
 
         if logger == "wandb" and not wandb.api.api_key:
@@ -212,6 +238,118 @@ class Trainer:
     @property
     def is_main(self):
         return self.accelerator.is_main_process
+
+    @staticmethod
+    def _validate_gradient_accumulation_steps(value):
+        """Normalize and validate the count before constructing Accelerate."""
+        if isinstance(value, bool):
+            raise ValueError("gradient_accumulation_steps must be a positive integer")
+        try:
+            normalized = operator.index(value)
+        except TypeError as exc:
+            raise ValueError("gradient_accumulation_steps must be a positive integer") from exc
+        if normalized < 1:
+            raise ValueError("gradient_accumulation_steps must be a positive integer")
+        return normalized
+
+    @staticmethod
+    def _normalize_checkpoint_args(update, consumed_updates=None, last=False):
+        """Keep the pre-cursor ``save_checkpoint(update, last=False)`` call valid."""
+        if isinstance(consumed_updates, bool):
+            if last:
+                raise TypeError("last was provided twice to save_checkpoint")
+            last = consumed_updates
+            consumed_updates = update
+        if consumed_updates is None:
+            consumed_updates = update
+        return update, consumed_updates, last
+
+    @staticmethod
+    def _set_dataloader_epoch(dataloader, epoch: int):
+        """Set epoch on Accelerate's wrapper and every nested sampler."""
+        pending = [dataloader]
+        seen = set()
+        while pending:
+            current = pending.pop(0)
+            if current is None or id(current) in seen:
+                continue
+            seen.add(id(current))
+            set_epoch = getattr(current, "set_epoch", None)
+            if callable(set_epoch):
+                set_epoch(epoch)
+            for attribute in ("batch_sampler", "sampler"):
+                nested = getattr(current, attribute, None)
+                if nested is not None:
+                    pending.append(nested)
+
+    def _prepare_global_masked_mean_dataloader(self, dataloader):
+        """Prepare GMM data without Accelerate's duplicate-batch padding.
+
+        ``even_batches=True`` can replay samples when the number of batches is
+        not divisible by the process count. GMM has no validity mask for such
+        synthetic samples, so reject an incomplete process group rather than
+        silently biasing the denominator or dropping a tail batch.
+        """
+        self.accelerator.even_batches = False
+        if getattr(self.accelerator, "dispatch_batches", False):
+            raise ValueError(
+                "global_masked_mean=True requires dispatch_batches=False so accumulation windows "
+                "can remain on the host until each microbatch is processed."
+            )
+        num_processes = int(getattr(self.accelerator, "num_processes", 1))
+        split_batches = bool(getattr(self.accelerator, "split_batches", False))
+        if num_processes > 1 and not split_batches and len(dataloader) % num_processes:
+            raise ValueError(
+                "global_masked_mean requires the prepared dataloader batch count to be divisible by "
+                f"the process count ({num_processes}); received {len(dataloader)} batches. "
+                "Increase/drop the final batch explicitly instead of allowing duplicate padding."
+            )
+        prepared = self.accelerator.prepare_data_loader(dataloader, device_placement=False)
+        self._validate_global_masked_dataloader(prepared)
+        return prepared
+
+    def _capture_rng_states(self):
+        """Capture per-process RNG state so resumed training does not replay masks."""
+        local_state = {
+            "python": random.getstate(),
+            "torch": torch.get_rng_state(),
+        }
+        if torch.cuda.is_available():
+            local_state["cuda"] = torch.cuda.get_rng_state_all()
+        dataloader_generator = getattr(self, "_train_dataloader_generator", None)
+        if dataloader_generator is not None:
+            local_state["dataloader_generator"] = dataloader_generator.get_state()
+
+        if dist.is_available() and dist.is_initialized():
+            states = [None] * dist.get_world_size()
+            dist.all_gather_object(states, local_state)
+            return states
+        return [local_state]
+
+    def _restore_rng_states(self, states):
+        """Restore the current process RNG state when checkpoint topology matches."""
+        if states is None:
+            return
+        expected_processes = int(getattr(self.accelerator, "num_processes", 1))
+        if len(states) != expected_processes:
+            raise ValueError(
+                "checkpoint RNG state was saved for "
+                f"{len(states)} processes, but the current run uses {expected_processes}; "
+                "resume with the same process count or start from model weights only."
+            )
+        process_index = int(getattr(self.accelerator, "process_index", 0))
+        state = states[process_index]
+        random.setstate(state["python"])
+        torch.set_rng_state(state["torch"])
+        if "cuda" in state and torch.cuda.is_available():
+            cuda_state = state["cuda"]
+            if isinstance(cuda_state, (list, tuple)):
+                torch.cuda.set_rng_state_all(list(cuda_state))
+            else:  # backward compatibility with checkpoints containing one CUDA state
+                torch.cuda.set_rng_state(cuda_state)
+        dataloader_generator = getattr(self, "_train_dataloader_generator", None)
+        if dataloader_generator is not None and "dataloader_generator" in state:
+            dataloader_generator.set_state(state["dataloader_generator"])
 
     # ---- torch.compile support (optional, default-off) ----
 
@@ -459,6 +597,8 @@ class Trainer:
             window = []
             local_loss_denom = torch.zeros((), device=self.accelerator.device, dtype=torch.int64)
             local_error = None
+            local_oom = None
+            local_exception = None
             for batch in batches:
                 batch_error = self._validate_global_masked_batch(batch)
                 rand_span_mask = None
@@ -469,6 +609,10 @@ class Trainer:
                         batch_loss_denom = rand_span_mask.sum(dtype=torch.int64) * mel.shape[1]
                         local_loss_denom = local_loss_denom + batch_loss_denom
                     except Exception as exc:
+                        if local_exception is None:
+                            local_exception = exc
+                        if _is_cuda_oom(exc):
+                            local_oom = exc
                         batch_error = f"training-mask preparation failed: {exc}"
                 if batch_error is not None and local_error is None:
                     local_error = batch_error
@@ -478,13 +622,24 @@ class Trainer:
                 (
                     local_loss_denom,
                     torch.tensor(int(local_error is not None), device=self.accelerator.device, dtype=torch.int64),
+                    torch.tensor(int(local_oom is not None), device=self.accelerator.device, dtype=torch.int64),
                 )
             )
             global_stats = self._reduce_global_masked_value(local_stats)
-            global_denom_value, global_error_count = global_stats.cpu().tolist()
+            global_denom_value, global_error_count, global_oom_count = global_stats.cpu().tolist()
             if global_error_count:
+                if global_oom_count:
+                    if local_oom is not None:
+                        raise local_oom
+                    raise RuntimeError(
+                        "global_masked_mean rejected an accumulation window because another rank reported "
+                        "CUDA out of memory during training-mask preparation."
+                    )
                 detail = local_error or "another rank reported malformed training input"
-                raise ValueError(f"global_masked_mean rejected an accumulation window: {detail}")
+                message = f"global_masked_mean rejected an accumulation window: {detail}"
+                if local_exception is not None:
+                    raise ValueError(message) from local_exception
+                raise ValueError(message)
             if global_denom_value == 0:
                 raise RuntimeError(
                     "global_masked_mean produced an empty accumulation window; "
@@ -541,6 +696,10 @@ class Trainer:
                 for item in text
             ):
                 return "text list entries must be strings or lists of strings"
+            if any(isinstance(item, list) for item in text) and getattr(
+                self._unwrapped_model, "vocab_char_map", None
+            ) is None:
+                return "nested text token lists require a vocabulary map"
         else:
             return "text must be a tensor or list"
         return None
@@ -580,7 +739,9 @@ class Trainer:
                 f"received per-rank lengths {lengths}."
             )
 
-    def save_checkpoint(self, update, consumed_updates, last=False):
+    def save_checkpoint(self, update, consumed_updates=None, last=False):
+        update, consumed_updates, last = self._normalize_checkpoint_args(update, consumed_updates, last)
+        rng_states = self._capture_rng_states()
         self.accelerator.wait_for_everyone()
         if self.is_main:
             checkpoint = dict(
@@ -590,6 +751,7 @@ class Trainer:
                 scheduler_state_dict=self.scheduler.state_dict(),
                 update=update,
                 consumed_updates=consumed_updates,
+                rng_state=rng_states,
             )
             if not os.path.exists(self.checkpoint_path):
                 os.makedirs(self.checkpoint_path)
@@ -616,13 +778,13 @@ class Trainer:
                         os.remove(os.path.join(self.checkpoint_path, oldest_checkpoint))
                         print(f"Removed old checkpoint: {oldest_checkpoint}")
 
-    def load_checkpoint(self):
+    def load_checkpoint(self, *, return_cursor=False):
         if (
             not exists(self.checkpoint_path)
             or not os.path.exists(self.checkpoint_path)
             or not any(filename.endswith((".pt", ".safetensors")) for filename in os.listdir(self.checkpoint_path))
         ):
-            return 0, 0
+            return (0, 0) if return_cursor else 0
 
         self.accelerator.wait_for_everyone()
         if "model_last.pt" in os.listdir(self.checkpoint_path):
@@ -652,10 +814,10 @@ class Trainer:
             checkpoint = load_file(f"{self.checkpoint_path}/{latest_checkpoint}", device="cpu")
             checkpoint = {"ema_model_state_dict": checkpoint}
         elif latest_checkpoint.endswith(".pt"):
-            # checkpoint = torch.load(f"{self.checkpoint_path}/{latest_checkpoint}", map_location=self.accelerator.device)  # rather use accelerator.load_state ಥ_ಥ
-            checkpoint = torch.load(
-                f"{self.checkpoint_path}/{latest_checkpoint}", weights_only=True, map_location="cpu"
-            )
+            load_kwargs: dict[str, Any] = {"map_location": "cpu"}
+            if "weights_only" in inspect.signature(torch.load).parameters:
+                load_kwargs["weights_only"] = True
+            checkpoint = torch.load(f"{self.checkpoint_path}/{latest_checkpoint}", **load_kwargs)
 
         # patch for backward compatibility, 305e3ea
         for key in ["ema_model.mel_spec.mel_stft.mel_scale.fb", "ema_model.mel_spec.mel_stft.spectrogram.window"]:
@@ -697,9 +859,10 @@ class Trainer:
             update = 0
             consumed_updates = 0
 
+        self._restore_rng_states(checkpoint.get("rng_state"))
         del checkpoint
         gc.collect()
-        return update, consumed_updates
+        return (update, consumed_updates) if return_cursor else update
 
     def train(self, train_dataset: Dataset, num_workers=16, resumable_with_seed: int = None):
         if self.log_samples:
@@ -712,15 +875,15 @@ class Trainer:
             log_samples_path = f"{self.checkpoint_path}/samples"
             os.makedirs(log_samples_path, exist_ok=True)
 
-        if exists(resumable_with_seed):
-            generator = torch.Generator()
-            generator.manual_seed(resumable_with_seed)
-        else:
-            generator = None
-
+        self._train_dataloader_generator = None
         persistent_workers = num_workers > 0
 
         if self.batch_size_type == "sample":
+            sample_sampler = None
+            if exists(resumable_with_seed):
+                self._train_dataloader_generator = torch.Generator()
+                self._train_dataloader_generator.manual_seed(resumable_with_seed)
+                sample_sampler = _EpochRandomSampler(train_dataset, resumable_with_seed)
             train_dataloader = DataLoader(
                 train_dataset,
                 collate_fn=collate_fn,
@@ -728,8 +891,9 @@ class Trainer:
                 pin_memory=True,
                 persistent_workers=persistent_workers,
                 batch_size=self.batch_size_per_gpu,
-                shuffle=True,
-                generator=generator,
+                shuffle=sample_sampler is None,
+                sampler=sample_sampler,
+                generator=self._train_dataloader_generator,
             )
         elif self.batch_size_type == "frame":
             self.accelerator.even_batches = False
@@ -770,19 +934,13 @@ class Trainer:
             # dataloader places each yielded batch on the accelerator, which
             # would retain G large mel batches and undermine accumulation's
             # memory bound. The window iterator transfers one batch at a time.
-            if self.accelerator.dispatch_batches:
-                raise ValueError(
-                    "global_masked_mean=True requires dispatch_batches=False so accumulation windows "
-                    "can remain on the host until each microbatch is processed."
-                )
-            train_dataloader = self.accelerator.prepare_data_loader(train_dataloader, device_placement=False)
+            train_dataloader = self._prepare_global_masked_mean_dataloader(train_dataloader)
             self.scheduler = self.accelerator.prepare(self.scheduler)
-            self._validate_global_masked_dataloader(train_dataloader)
         else:
             train_dataloader, self.scheduler = self.accelerator.prepare(
                 train_dataloader, self.scheduler
             )  # actual multi_gpu updates = single_gpu updates / gpu nums
-        start_update, start_consumed_updates = self.load_checkpoint()
+        start_update, start_consumed_updates = self.load_checkpoint(return_cursor=True)
         global_update = start_update
         consumed_updates = start_consumed_updates
 
@@ -805,9 +963,7 @@ class Trainer:
                 progress_bar_initial = 0
                 current_dataloader = train_dataloader
 
-            # Set epoch for the batch sampler if it exists
-            if hasattr(train_dataloader, "batch_sampler") and hasattr(train_dataloader.batch_sampler, "set_epoch"):
-                train_dataloader.batch_sampler.set_epoch(epoch)
+            self._set_dataloader_epoch(current_dataloader, epoch)
 
             progress_bar = tqdm(
                 range(math.ceil(len(train_dataloader) / self.grad_accumulation_steps)),
@@ -866,7 +1022,9 @@ class Trainer:
                         self.accelerator.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
 
                     self.optimizer.step()
-                    self.scheduler.step()
+                    optimizer_step_was_skipped = bool(getattr(self.accelerator, "optimizer_step_was_skipped", False))
+                    if not optimizer_step_was_skipped:
+                        self.scheduler.step()
                     self.optimizer.zero_grad()
 
                 if self.global_masked_mean and self.accelerator.sync_gradients:
@@ -880,8 +1038,8 @@ class Trainer:
                 else:
                     loss_to_log = loss.item()
 
-                update_completed = self.accelerator.sync_gradients and (
-                    not self.global_masked_mean or not self.accelerator.optimizer_step_was_skipped
+                update_completed = self.accelerator.sync_gradients and not bool(
+                    getattr(self.accelerator, "optimizer_step_was_skipped", False)
                 )
                 if self.accelerator.sync_gradients:
                     consumed_updates += 1

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -4,13 +4,14 @@ import gc
 import inspect
 import math
 import os
+from contextlib import contextmanager, nullcontext
 from typing import Any, cast
 
 import torch
 import torchaudio
 import wandb
 from accelerate import Accelerator
-from accelerate.utils import DistributedDataParallelKwargs
+from accelerate.utils import DistributedDataParallelKwargs, DistributedType, send_to_device
 from ema_pytorch import EMA
 from torch.optim import AdamW
 from torch.optim.lr_scheduler import LinearLR, SequentialLR
@@ -91,6 +92,7 @@ class Trainer:
         compile_fullgraph: bool = False,
         compile_dynamic: bool | None = None,
         compile_fallback_to_eager: bool = True,
+        global_masked_mean: bool = False,
     ):
         ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
 
@@ -104,6 +106,10 @@ class Trainer:
             gradient_accumulation_steps=grad_accumulation_steps,
             **accelerate_kwargs,
         )
+        self.global_masked_mean = global_masked_mean
+        self.grad_accumulation_steps = grad_accumulation_steps
+        self.max_grad_norm = max_grad_norm
+        self._validate_global_masked_mean_config()
 
         self.logger = logger
         if self.logger == "wandb":
@@ -161,8 +167,6 @@ class Trainer:
         self.batch_size_per_gpu = batch_size_per_gpu
         self.batch_size_type = batch_size_type
         self.max_samples = max_samples
-        self.grad_accumulation_steps = grad_accumulation_steps
-        self.max_grad_norm = max_grad_norm
 
         # mel vocoder config
         self.vocoder_name = mel_spec_type
@@ -193,6 +197,7 @@ class Trainer:
             self.optimizer = AdamW(model.parameters(), lr=learning_rate, fused=True)
         self.model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
         self._unwrapped_model = self.accelerator.unwrap_model(self.model)
+        self._validate_global_masked_mean_backend()
         self._configure_compile()
 
     @property
@@ -200,6 +205,84 @@ class Trainer:
         return self.accelerator.is_main_process
 
     # ---- torch.compile support (optional, default-off) ----
+
+    def _validate_global_masked_mean_config(self):
+        """Reject incompatible distributed configurations before model setup."""
+        if not self.global_masked_mean:
+            return
+        if self.accelerator.distributed_type in (DistributedType.FSDP, DistributedType.MEGATRON_LM):
+            raise NotImplementedError(
+                f"global_masked_mean=True does not support {self.accelerator.distributed_type.value}; "
+                "the current F5-TTS EMA and checkpoint path is not compatible with sharded model parameters."
+            )
+        if self.accelerator.distributed_type != DistributedType.DEEPSPEED:
+            return
+
+        deepspeed_plugin = self.accelerator.state.deepspeed_plugin
+        zero_stage = int(getattr(deepspeed_plugin, "zero_stage", 0))
+        if zero_stage != 0:
+            raise NotImplementedError(
+                "global_masked_mean currently supports DeepSpeed ZeRO stage 0 only. "
+                "F5-TTS checkpointing saves optimizer state on rank 0 and its EMA requires full parameters, "
+                "so enabling sharded ZeRO stages would produce incomplete checkpoints or invalid EMA updates."
+            )
+
+        configured_gas = deepspeed_plugin.get_value("gradient_accumulation_steps")
+        if configured_gas not in (None, "auto") and int(configured_gas) != self.grad_accumulation_steps:
+            raise ValueError(
+                "DeepSpeed and Trainer gradient accumulation steps must match for global_masked_mean=True."
+            )
+
+        deepspeed_clip = deepspeed_plugin.get_value("gradient_clipping")
+        expected_clip = self.max_grad_norm if self.max_grad_norm > 0 else 0.0
+        if deepspeed_clip in (None, "auto"):
+            deepspeed_plugin.deepspeed_config["gradient_clipping"] = expected_clip
+        elif float(deepspeed_clip) != float(expected_clip):
+            raise ValueError(
+                "DeepSpeed gradient_clipping must match Trainer.max_grad_norm for global_masked_mean=True "
+                "because DeepSpeed steps inside Accelerator.backward()."
+            )
+
+    def _validate_global_masked_mean_backend(self):
+        """Validate the prepared DeepSpeed engine required by manual boundaries."""
+        if not self.global_masked_mean or self.accelerator.distributed_type != DistributedType.DEEPSPEED:
+            return
+
+        set_boundary = getattr(self.model, "set_gradient_accumulation_boundary", None)
+        if not callable(set_boundary):
+            raise NotImplementedError(
+                "global_masked_mean=True requires DeepSpeedEngine.set_gradient_accumulation_boundary()."
+            )
+
+        # One denominator is correct only when every process is a replica in
+        # the same data-parallel group. F5-TTS does not configure these
+        # model-parallel modes, but reject externally supplied combinations
+        # rather than silently over-counting their replicated samples.
+        unsupported_modes = []
+        if getattr(self.model, "sequence_parallel_size", 1) != 1:
+            unsupported_modes.append("sequence parallelism")
+        if getattr(self.model, "mp_world_size", 1) != 1:
+            unsupported_modes.append("model parallelism")
+        if getattr(self.model, "pipeline_parallelism", False):
+            unsupported_modes.append("pipeline parallelism")
+        if getattr(self.model, "has_moe_layers", False):
+            unsupported_modes.append("MoE expert parallelism")
+        if getattr(self.model, "dp_world_size", self.accelerator.num_processes) != self.accelerator.num_processes:
+            unsupported_modes.append("a non-world data-parallel group")
+        if unsupported_modes:
+            modes = ", ".join(unsupported_modes)
+            raise NotImplementedError(f"global_masked_mean=True does not yet support DeepSpeed {modes}.")
+
+        accelerator_gas = int(self.accelerator.gradient_accumulation_steps)
+        if accelerator_gas != self.grad_accumulation_steps:
+            raise ValueError(
+                "Accelerator and Trainer gradient accumulation steps must match for global_masked_mean=True."
+            )
+        deepspeed_gas = getattr(self.model, "gradient_accumulation_steps", None)
+        if callable(deepspeed_gas) and int(deepspeed_gas()) != self.grad_accumulation_steps:
+            raise ValueError(
+                "DeepSpeed and Trainer gradient accumulation steps must match for global_masked_mean=True."
+            )
 
     def _configure_compile(self):
         """Set up torch.compile on the CFM loss core if enabled.
@@ -339,7 +422,152 @@ class Trainer:
             self.compile_active = False
             self.compile_fallback_active = True
 
-    def save_checkpoint(self, update, last=False):
+    def _reduce_global_masked_value(self, local_value: torch.Tensor) -> torch.Tensor:
+        """Sum a detached scalar over the supported data-parallel group."""
+        local_value = local_value.detach().to(device=self.accelerator.device)
+        return cast(torch.Tensor, self.accelerator.reduce(local_value, reduction="sum"))
+
+    def _iter_global_masked_mean_batches(self, dataloader):
+        """Yield pre-normalized accumulation windows without retaining graphs."""
+        dataloader_iter = iter(dataloader)
+        sample_mask = getattr(self._unwrapped_model, "sample_training_mask", None)
+        if not callable(sample_mask):
+            raise TypeError("The training model does not expose sample_training_mask().")
+
+        while True:
+            batches = []
+
+            for _ in range(self.grad_accumulation_steps):
+                try:
+                    batch = next(dataloader_iter)
+                except StopIteration:
+                    break
+                batches.append(batch)
+
+            if not batches:
+                return
+
+            window = []
+            local_loss_denom = torch.zeros((), device=self.accelerator.device, dtype=torch.int64)
+            local_error = None
+            for batch in batches:
+                batch_error = self._validate_global_masked_batch(batch)
+                rand_span_mask = None
+                if batch_error is None:
+                    try:
+                        mel = batch["mel"]
+                        rand_span_mask = sample_mask(batch["mel_lengths"], mel.shape[-1])
+                        batch_loss_denom = rand_span_mask.sum(dtype=torch.int64) * mel.shape[1]
+                        local_loss_denom = local_loss_denom + batch_loss_denom
+                    except Exception as exc:
+                        batch_error = f"training-mask preparation failed: {exc}"
+                if batch_error is not None and local_error is None:
+                    local_error = batch_error
+                window.append((batch, rand_span_mask))
+
+            local_stats = torch.stack(
+                (
+                    local_loss_denom,
+                    torch.tensor(int(local_error is not None), device=self.accelerator.device, dtype=torch.int64),
+                )
+            )
+            global_stats = self._reduce_global_masked_value(local_stats)
+            global_denom_value, global_error_count = global_stats.cpu().tolist()
+            if global_error_count:
+                detail = local_error or "another rank reported malformed training input"
+                raise ValueError(f"global_masked_mean rejected an accumulation window: {detail}")
+            if global_denom_value == 0:
+                raise RuntimeError(
+                    "global_masked_mean produced an empty accumulation window; "
+                    "no optimizer update can be defined without masked elements."
+                )
+            global_loss_denom = global_stats[0]
+            loss_scale = global_loss_denom.to(dtype=torch.float32).reciprocal()
+            loss_scale = loss_scale * (self.grad_accumulation_steps * self.accelerator.num_processes)
+
+            for index, (batch, rand_span_mask) in enumerate(window):
+                assert rand_span_mask is not None
+                is_boundary = index == len(window) - 1
+                yield batch, rand_span_mask, loss_scale, global_loss_denom, is_boundary
+
+    def _validate_global_masked_batch(self, batch) -> str | None:
+        """Return a rank-local validation error without raising before collectives."""
+        if not isinstance(batch, dict):
+            return f"expected a batch dictionary, received {type(batch).__name__}"
+        if "mel" not in batch or "mel_lengths" not in batch or "text" not in batch:
+            return "batch must contain mel, mel_lengths, and text"
+
+        mel = batch["mel"]
+        mel_lengths = batch["mel_lengths"]
+        if not isinstance(mel, torch.Tensor) or mel.ndim != 3:
+            return "mel must be a rank-3 tensor shaped [batch, channels, frames]"
+        if not mel.is_floating_point():
+            return f"mel must use a floating-point dtype, received {mel.dtype}"
+        if mel.shape[0] == 0:
+            return "mel batch must not be empty"
+        expected_channels = getattr(self._unwrapped_model, "num_channels", mel.shape[1])
+        if mel.shape[1] != expected_channels:
+            return f"mel channel count must be {expected_channels}, received {mel.shape[1]}"
+        if not isinstance(mel_lengths, torch.Tensor) or mel_lengths.ndim != 1:
+            return "mel_lengths must be a rank-1 tensor"
+        if mel_lengths.shape[0] != mel.shape[0]:
+            return "mel_lengths count must match the mel batch size"
+        if mel_lengths.dtype == torch.bool or mel_lengths.is_floating_point() or mel_lengths.is_complex():
+            return f"mel_lengths must use an integer dtype, received {mel_lengths.dtype}"
+        if bool(((mel_lengths <= 0) | (mel_lengths > mel.shape[-1])).any().item()):
+            return f"mel_lengths values must be between 1 and the padded frame length ({mel.shape[-1]})"
+
+        text = batch["text"]
+        if isinstance(text, torch.Tensor):
+            if text.ndim == 0 or text.shape[0] != mel.shape[0]:
+                return "tensor text batch size must match the mel batch size"
+            if text.dtype == torch.bool or text.is_floating_point() or text.is_complex():
+                return f"tensor text must use an integer dtype, received {text.dtype}"
+        elif isinstance(text, list):
+            if len(text) != mel.shape[0]:
+                return "text list size must match the mel batch size"
+            if any(not isinstance(item, str) for item in text):
+                return "text list entries must be strings"
+        else:
+            return "text must be a tensor or list"
+        return None
+
+    @contextmanager
+    def _accumulation_context(self, is_boundary: bool | None):
+        """Select automatic or explicit accumulation without backend ambiguity."""
+        if is_boundary is None:
+            with self.accelerator.accumulate(self.model):
+                yield
+            return
+
+        self.accelerator.sync_gradients = is_boundary
+        if self.accelerator.distributed_type == DistributedType.DEEPSPEED:
+            # Accelerate 0.33 always calls DeepSpeedEngine.step() from backward,
+            # while newer releases propagate sync_gradients themselves. Setting
+            # the public engine boundary works in both implementations and is
+            # required to flush a final partial accumulation window.
+            self.model.set_gradient_accumulation_boundary(is_boundary)
+            sync_context = nullcontext()
+        else:
+            sync_context = nullcontext() if is_boundary else self.accelerator.no_sync(self.model)
+
+        with sync_context:
+            yield
+
+    def _validate_global_masked_dataloader(self, dataloader):
+        """Fail collectively if ranks would execute different forward counts."""
+        local_length = torch.tensor([len(dataloader)], device=self.accelerator.device, dtype=torch.int64)
+        gathered_lengths = cast(torch.Tensor, self.accelerator.gather(local_length))
+        if gathered_lengths[0].item() == 0:
+            raise ValueError("global_masked_mean requires a non-empty training dataloader.")
+        if bool((gathered_lengths != gathered_lengths[0]).any().item()):
+            lengths = gathered_lengths.cpu().tolist()
+            raise RuntimeError(
+                "global_masked_mean requires the same number of dataloader batches on every rank; "
+                f"received per-rank lengths {lengths}."
+            )
+
+    def save_checkpoint(self, update, consumed_updates, last=False):
         self.accelerator.wait_for_everyone()
         if self.is_main:
             checkpoint = dict(
@@ -348,6 +576,7 @@ class Trainer:
                 ema_model_state_dict=self.ema_model.state_dict(),
                 scheduler_state_dict=self.scheduler.state_dict(),
                 update=update,
+                consumed_updates=consumed_updates,
             )
             if not os.path.exists(self.checkpoint_path):
                 os.makedirs(self.checkpoint_path)
@@ -380,7 +609,7 @@ class Trainer:
             or not os.path.exists(self.checkpoint_path)
             or not any(filename.endswith((".pt", ".safetensors")) for filename in os.listdir(self.checkpoint_path))
         ):
-            return 0
+            return 0, 0
 
         self.accelerator.wait_for_everyone()
         if "model_last.pt" in os.listdir(self.checkpoint_path):
@@ -441,6 +670,10 @@ class Trainer:
             if self.scheduler:
                 self.scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
             update = checkpoint["update"]
+            # Optimizer overflows consume an accumulation window without
+            # completing an update. Older checkpoints predate that distinction
+            # and advanced "update" for every consumed window.
+            consumed_updates = checkpoint.get("consumed_updates", update)
         else:
             checkpoint["model_state_dict"] = {
                 k.replace("ema_model.", ""): v
@@ -449,10 +682,11 @@ class Trainer:
             }
             self.accelerator.unwrap_model(self.model).load_state_dict(checkpoint["model_state_dict"])
             update = 0
+            consumed_updates = 0
 
         del checkpoint
         gc.collect()
-        return update
+        return update, consumed_updates
 
     def train(self, train_dataset: Dataset, num_workers=16, resumable_with_seed: int = None):
         if self.log_samples:
@@ -516,17 +750,33 @@ class Trainer:
         self.scheduler = SequentialLR(
             self.optimizer, schedulers=[warmup_scheduler, decay_scheduler], milestones=[warmup_updates]
         )
-        train_dataloader, self.scheduler = self.accelerator.prepare(
-            train_dataloader, self.scheduler
-        )  # actual multi_gpu updates = single_gpu updates / gpu nums
-        start_update = self.load_checkpoint()
+        if self.global_masked_mean:
+            # Buffer accumulation windows on the host. A normally prepared
+            # dataloader places each yielded batch on the accelerator, which
+            # would retain G large mel batches and undermine accumulation's
+            # memory bound. The window iterator transfers one batch at a time.
+            if self.accelerator.dispatch_batches:
+                raise ValueError(
+                    "global_masked_mean=True requires dispatch_batches=False so accumulation windows "
+                    "can remain on the host until each microbatch is processed."
+                )
+            train_dataloader = self.accelerator.prepare_data_loader(train_dataloader, device_placement=False)
+            self.scheduler = self.accelerator.prepare(self.scheduler)
+            self._validate_global_masked_dataloader(train_dataloader)
+        else:
+            train_dataloader, self.scheduler = self.accelerator.prepare(
+                train_dataloader, self.scheduler
+            )  # actual multi_gpu updates = single_gpu updates / gpu nums
+        start_update, start_consumed_updates = self.load_checkpoint()
         global_update = start_update
+        consumed_updates = start_consumed_updates
 
         if exists(resumable_with_seed):
             orig_epoch_step = len(train_dataloader)
-            start_step = start_update * self.grad_accumulation_steps
-            skipped_epoch = int(start_step // orig_epoch_step)
-            skipped_batch = start_step % orig_epoch_step
+            updates_per_epoch = math.ceil(orig_epoch_step / self.grad_accumulation_steps)
+            skipped_epoch = int(start_consumed_updates // updates_per_epoch)
+            updates_into_epoch = start_consumed_updates % updates_per_epoch
+            skipped_batch = min(updates_into_epoch * self.grad_accumulation_steps, orig_epoch_step)
             skipped_dataloader = self.accelerator.skip_first_batches(train_dataloader, num_batches=skipped_batch)
         else:
             skipped_epoch = 0
@@ -552,8 +802,16 @@ class Trainer:
                 initial=progress_bar_initial,
             )
 
-            for batch in current_dataloader:
-                with self.accelerator.accumulate(self.model):
+            if self.global_masked_mean:
+                training_batches = self._iter_global_masked_mean_batches(current_dataloader)
+            else:
+                training_batches = ((batch, None, None, None, None) for batch in current_dataloader)
+
+            loss_sum_accum = None
+            for batch, rand_span_mask, loss_scale, global_loss_denom, is_boundary in training_batches:
+                if self.global_masked_mean:
+                    batch = send_to_device(batch, self.accelerator.device, non_blocking=True)
+                with self._accumulation_context(is_boundary):
                     text_inputs = batch["text"]
                     mel_spec = batch["mel"].permute(0, 2, 1)
                     mel_lengths = batch["mel_lengths"]
@@ -563,40 +821,89 @@ class Trainer:
                         dur_loss = self.duration_predictor(mel_spec, lens=batch.get("durations"))
                         self.accelerator.log({"duration loss": dur_loss.item()}, step=global_update)
 
-                    loss, cond, pred = self.model(
-                        mel_spec, text=text_inputs, lens=mel_lengths, noise_scheduler=self.noise_scheduler
-                    )
-                    self._check_compile_runtime_fallback()
-                    self.accelerator.backward(loss)
+                    if self.global_masked_mean:
+                        assert rand_span_mask is not None
+                        assert loss_scale is not None
+                        loss, loss_sum, loss_denom, cond, pred = self.model(
+                            mel_spec,
+                            text=text_inputs,
+                            lens=mel_lengths,
+                            noise_scheduler=self.noise_scheduler,
+                            rand_span_mask=rand_span_mask,
+                            return_loss_components=True,
+                        )
+                        loss_sum_accum = (
+                            loss_sum.detach() if loss_sum_accum is None else loss_sum_accum + loss_sum.detach()
+                        )
+                        self._check_compile_runtime_fallback()
+                        self.accelerator.backward(loss_sum * loss_scale)
+                    else:
+                        loss, cond, pred = self.model(
+                            mel_spec, text=text_inputs, lens=mel_lengths, noise_scheduler=self.noise_scheduler
+                        )
+                        self._check_compile_runtime_fallback()
+                        self.accelerator.backward(loss)
 
-                    if self.max_grad_norm > 0 and self.accelerator.sync_gradients:
+                    deepspeed_clips_in_backward = (
+                        self.global_masked_mean and self.accelerator.distributed_type == DistributedType.DEEPSPEED
+                    )
+                    if self.max_grad_norm > 0 and self.accelerator.sync_gradients and not deepspeed_clips_in_backward:
                         self.accelerator.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
 
                     self.optimizer.step()
                     self.scheduler.step()
                     self.optimizer.zero_grad()
 
+                if self.global_masked_mean and self.accelerator.sync_gradients:
+                    assert loss_sum_accum is not None
+                    assert global_loss_denom is not None
+                    global_loss_sum = self._reduce_global_masked_value(loss_sum_accum.to(dtype=torch.float32))
+                    loss_to_log = (global_loss_sum / global_loss_denom.to(dtype=torch.float32)).item()
+                    loss_sum_accum = None
+                elif self.global_masked_mean:
+                    loss_to_log = None
+                else:
+                    loss_to_log = loss.item()
+
+                update_completed = self.accelerator.sync_gradients and (
+                    not self.global_masked_mean or not self.accelerator.optimizer_step_was_skipped
+                )
                 if self.accelerator.sync_gradients:
+                    consumed_updates += 1
+                    progress_bar.update(1)
+
+                if update_completed:
                     if self.is_main:
                         self.ema_model.update()
 
                     global_update += 1
-                    progress_bar.update(1)
-                    progress_bar.set_postfix(update=str(global_update), loss=loss.item())
+                if self.accelerator.sync_gradients:
+                    assert loss_to_log is not None
+                    if self.global_masked_mean:
+                        progress_bar.set_postfix(
+                            update=str(global_update),
+                            loss=loss_to_log,
+                            skipped=not update_completed,
+                        )
+                    else:
+                        progress_bar.set_postfix(update=str(global_update), loss=loss_to_log)
 
-                if self.accelerator.is_local_main_process:
+                should_log = not self.global_masked_mean or self.accelerator.sync_gradients
+                if self.accelerator.is_local_main_process and should_log:
+                    assert loss_to_log is not None
                     self.accelerator.log(
-                        {"loss": loss.item(), "lr": self.scheduler.get_last_lr()[0]}, step=global_update
+                        {"loss": loss_to_log, "lr": self.scheduler.get_last_lr()[0]}, step=global_update
                     )
-                if self.logger == "tensorboard" and self.accelerator.is_main_process:
-                    self.writer.add_scalar("loss", loss.item(), global_update)
+                if self.logger == "tensorboard" and self.accelerator.is_main_process and should_log:
+                    assert loss_to_log is not None
+                    self.writer.add_scalar("loss", loss_to_log, global_update)
                     self.writer.add_scalar("lr", self.scheduler.get_last_lr()[0], global_update)
 
-                if global_update % self.last_per_updates == 0 and self.accelerator.sync_gradients:
-                    self.save_checkpoint(global_update, last=True)
+                if global_update % self.last_per_updates == 0 and update_completed:
+                    self.save_checkpoint(global_update, consumed_updates, last=True)
 
-                if global_update % self.save_per_updates == 0 and self.accelerator.sync_gradients:
-                    self.save_checkpoint(global_update)
+                if global_update % self.save_per_updates == 0 and update_completed:
+                    self.save_checkpoint(global_update, consumed_updates)
 
                     if self.log_samples and self.accelerator.is_local_main_process:
                         ref_audio_len = mel_lengths[0]
@@ -643,6 +950,6 @@ class Trainer:
                         finally:
                             sample_model.train(was_training)
 
-        self.save_checkpoint(global_update, last=True)
+        self.save_checkpoint(global_update, consumed_updates, last=True)
 
         self.accelerator.end_training()

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -696,9 +696,10 @@ class Trainer:
                 for item in text
             ):
                 return "text list entries must be strings or lists of strings"
-            if any(isinstance(item, list) for item in text) and getattr(
-                self._unwrapped_model, "vocab_char_map", None
-            ) is None:
+            if (
+                any(isinstance(item, list) for item in text)
+                and getattr(self._unwrapped_model, "vocab_char_map", None) is None
+            ):
                 return "nested text token lists require a vocabulary map"
         else:
             return "text must be a tensor or list"

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import gc
+import inspect
 import math
 import os
+from typing import Any, cast
 
 import torch
 import torchaudio
@@ -18,6 +20,35 @@ from tqdm import tqdm
 from f5_tts.model import CFM
 from f5_tts.model.dataset import DynamicBatchSampler, collate_fn
 from f5_tts.model.utils import default, exists
+
+
+def _resolve_compile_dynamic(
+    requested: bool | None,
+    compile_fn: Any,
+) -> bool | None:
+    """Resolve ``dynamic=None`` across torch.compile API generations.
+
+    PyTorch 2.0 exposed ``dynamic=False`` as the callable default, while newer
+    releases use ``None`` for automatic dynamic-shape detection. Preserve an
+    explicit user choice on every release. For the auto setting, opt into
+    ``dynamic=True`` only when the callable's published signature proves that
+    omission would select the legacy static default.
+
+    Signature inspection follows ``functools.wraps`` metadata. If a custom or
+    monkeypatched callable has no trustworthy signature, leave the argument
+    unset rather than guessing at an API it may not support.
+    """
+    if requested is not None:
+        return requested
+
+    try:
+        dynamic_parameter = inspect.signature(compile_fn, follow_wrapped=True).parameters.get("dynamic")
+    except Exception:
+        return None
+
+    if dynamic_parameter is not None and dynamic_parameter.default is False:
+        return True
+    return None
 
 
 # trainer
@@ -53,6 +84,13 @@ class Trainer:
         is_local_vocoder: bool = False,  # use local path vocoder
         local_vocoder_path: str = "",  # local vocoder path
         model_cfg_dict: dict = dict(),  # training config
+        compile_enabled: bool = False,
+        compile_backend: str | None = "inductor",
+        compile_target: str = "cfm_loss_core",
+        compile_mode: str | None = None,
+        compile_fullgraph: bool = False,
+        compile_dynamic: bool | None = None,
+        compile_fallback_to_eager: bool = True,
     ):
         ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
 
@@ -135,6 +173,18 @@ class Trainer:
 
         self.duration_predictor = duration_predictor
 
+        # torch.compile configuration (optional, default-off)
+        self.compile_enabled = compile_enabled
+        self.compile_backend = compile_backend
+        self.compile_target = compile_target
+        self.compile_mode = compile_mode
+        self.compile_fullgraph = compile_fullgraph
+        self.compile_dynamic = compile_dynamic
+        self.compile_fallback_to_eager = compile_fallback_to_eager
+        self.compile_active = False
+        self.compile_fallback_active = False
+        self._unwrapped_model = None  # cached after accelerator.prepare
+
         if bnb_optimizer:
             import bitsandbytes as bnb
 
@@ -142,10 +192,152 @@ class Trainer:
         else:
             self.optimizer = AdamW(model.parameters(), lr=learning_rate, fused=True)
         self.model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
+        self._unwrapped_model = self.accelerator.unwrap_model(self.model)
+        self._configure_compile()
 
     @property
     def is_main(self):
         return self.accelerator.is_main_process
+
+    # ---- torch.compile support (optional, default-off) ----
+
+    def _configure_compile(self):
+        """Set up torch.compile on the CFM loss core if enabled.
+
+        Compilation is lazy (triggered by the first real training batch); there is no
+        synthetic preflight, which avoids shape/vocab mismatches with arbitrary models.
+        In DDP (num_processes > 1) runtime fallback is disabled: a per-rank eager fallback
+        would desynchronise the gradient all-reduce. Setup-time fallback is still allowed
+        and synchronised across ranks via ``_sync_compile_setup_ddp``.
+
+        Strict mode (``compile_fallback_to_eager=False``): a rank-local setup exception is
+        deferred until *every* rank has participated in the status collective
+        (``_sync_compile_setup_ddp``), then all ranks raise coherently -- the failing rank
+        re-raises its original exception, peers raise a collective-failure error. This
+        prevents a rank-divergent setup failure from stranding healthy ranks in an
+        unmatched collective. Single-process preserves the original immediate re-raise.
+        """
+        if not self.compile_enabled:
+            return
+
+        if not hasattr(torch, "compile"):
+            # torch.compile unavailable: participate in the collective before raising.
+            self.compile_active = False
+            if self.compile_fallback_to_eager:
+                self.compile_fallback_active = True
+                if self.is_main:
+                    print("torch.compile is unavailable; falling back to eager training.")
+            self._sync_compile_setup_ddp(local_failed=True)
+            if not self.compile_fallback_to_eager:
+                raise RuntimeError("torch.compile is unavailable in this PyTorch build")
+            return
+
+        effective_compile_dynamic = _resolve_compile_dynamic(self.compile_dynamic, torch.compile)
+        compile_kwargs = {
+            "backend": self.compile_backend,
+            "mode": self.compile_mode,
+            "fullgraph": self.compile_fullgraph,
+            "dynamic": effective_compile_dynamic,
+        }
+        compile_kwargs = {k: v for k, v in compile_kwargs.items() if v is not None}
+
+        # Under DDP, disable runtime fallback so a compile failure raises on all ranks
+        # (collective-safe) instead of one rank silently going eager.
+        runtime_fallback = self.compile_fallback_to_eager and self.accelerator.num_processes <= 1
+
+        setup_exc: Exception | None = None
+        try:
+            compile_fn = getattr(self._unwrapped_model, "compile_training_core", None)
+            if compile_fn is None:
+                raise TypeError("The training model does not expose compile_training_core()")
+            compile_target = getattr(self, "compile_target", "cfm_loss_core")
+            compile_fn(target=compile_target, runtime_fallback=runtime_fallback, **compile_kwargs)
+            self.compile_active = True
+        except Exception as exc:
+            # Defer the strict-mode re-raise until after the collective so every rank
+            # participates before any rank raises. Store the exception; in fallback mode
+            # also mark/clear for eager continuation. In strict mode compile_fallback_active
+            # stays False (we are not falling back — we are about to raise).
+            setup_exc = exc
+            self.compile_active = False
+            if self.compile_fallback_to_eager:
+                self.compile_fallback_active = True
+                if self.is_main:
+                    print(f"torch.compile setup failed; falling back to eager training. Error: {exc}")
+                clear_fn = getattr(self._unwrapped_model, "clear_training_compile", None)
+                if clear_fn is not None:
+                    clear_fn()
+
+        # Every rank participates in the status exchange before any rank raises.
+        any_failed = self._sync_compile_setup_ddp(local_failed=setup_exc is not None)
+
+        # Strict mode: raise coherently on ALL ranks after the collective.
+        if any_failed and not self.compile_fallback_to_eager:
+            if setup_exc is not None:
+                raise setup_exc
+            raise RuntimeError("torch.compile setup failed on at least one rank; aborting (strict mode).")
+
+        if self.compile_active and self.is_main:
+            compile_target = getattr(self, "compile_target", "cfm_loss_core")
+            print(
+                f"torch.compile enabled (target={compile_target}, backend={self.compile_backend}, "
+                f"mode={self.compile_mode}, fullgraph={self.compile_fullgraph}, "
+                f"dynamic={effective_compile_dynamic})"
+            )
+            if self.accelerator.num_processes > 1 and self.compile_fallback_to_eager:
+                print("DDP detected: runtime compile fallback disabled (errors will raise on all ranks).")
+
+    def _sync_compile_setup_ddp(self, local_failed: bool = False) -> bool:
+        """Exchange setup-time compile status across DDP ranks via a single reduce.
+
+        Every rank participates before any rank raises, so a rank-divergent setup failure
+        cannot strand peers in an unmatched collective. ``local_failed`` carries strict-
+        mode failures (where ``compile_fallback_active`` is not set because we are about to
+        raise, not fall back). Returns ``True`` if any rank reported a setup failure. In
+        fallback mode, all ranks switch to eager so the gradient all-reduce stays
+        consistent. In strict mode the caller raises after this returns (see
+        ``_configure_compile``).
+
+        Uses ``accelerator.reduce(..., reduction='max')`` on a 0/1 flag rather than a raw
+        ``torch.distributed.all_reduce`` so the collective goes through Accelerate's
+        dispatch layer (handles DeepSpeed/FSDP process groups correctly). Single-process
+        returns the local flag directly with no collective.
+
+        This covers setup only. A compile failure that first surfaces at *runtime* on a
+        single rank is deliberately fatal for that rank (runtime fallback is disabled under
+        DDP, see ``_configure_compile``): the alternative, one rank silently going eager,
+        would desynchronise gradients and corrupt training silently. A dying rank aborts
+        the job through the launcher, which is the intended fail-fast behaviour -- it is
+        not a graceful, collective-safe recovery, and no per-step collective is added to
+        make it one because that cost would be paid by every healthy step.
+        """
+        failed = local_failed or self.compile_fallback_active
+        if self.accelerator.num_processes <= 1:
+            return failed
+        flag = torch.tensor(1.0 if failed else 0.0, device=self.accelerator.device)
+        flag = cast(torch.Tensor, self.accelerator.reduce(flag, reduction="max"))
+        any_failed = float(flag) > 0.0
+        if any_failed and self.compile_active:
+            if self.is_main:
+                print("torch.compile setup failed on at least one rank; switching all ranks to eager.")
+            clear_fn = getattr(self._unwrapped_model, "clear_training_compile", None)
+            if clear_fn is not None:
+                clear_fn()
+            self.compile_active = False
+        if any_failed:
+            self.compile_fallback_active = True
+        return any_failed
+
+    def _check_compile_runtime_fallback(self):
+        """Detect a runtime compile failure surfaced by the CFM module and update trainer state."""
+        if not self.compile_active:
+            return
+        state = getattr(self._unwrapped_model, "training_compile_state", None)
+        if state is not None and state["fallback_active"]:
+            if self.is_main:
+                print(f"torch.compile runtime failed; continuing eagerly. Error: {state['error']}")
+            self.compile_active = False
+            self.compile_fallback_active = True
 
     def save_checkpoint(self, update, last=False):
         self.accelerator.wait_for_everyone()
@@ -374,6 +566,7 @@ class Trainer:
                     loss, cond, pred = self.model(
                         mel_spec, text=text_inputs, lens=mel_lengths, noise_scheduler=self.noise_scheduler
                     )
+                    self._check_compile_runtime_fallback()
                     self.accelerator.backward(loss)
 
                     if self.max_grad_norm > 0 and self.accelerator.sync_gradients:
@@ -410,32 +603,45 @@ class Trainer:
                         infer_text = [
                             text_inputs[0] + ([" "] if isinstance(text_inputs[0], list) else " ") + text_inputs[0]
                         ]
-                        with torch.inference_mode(), self.accelerator.autocast():
-                            generated, _ = self.accelerator.unwrap_model(self.model).sample(
-                                cond=mel_spec[0][:ref_audio_len].unsqueeze(0),
-                                text=infer_text,
-                                duration=ref_audio_len * 2,
-                                steps=nfe_step,
-                                cfg_strength=cfg_strength,
-                                sway_sampling_coef=sway_sampling_coef,
-                            )
-                            generated = generated.to(torch.float32)
-                            gen_mel_spec = generated[:, ref_audio_len:, :].permute(0, 2, 1).to(self.accelerator.device)
-                            ref_mel_spec = batch["mel"][0, :, :ref_audio_len].unsqueeze(0)
-                            if self.vocoder_name == "vocos":
-                                gen_audio = vocoder.decode(gen_mel_spec).cpu()
-                                ref_audio = vocoder.decode(ref_mel_spec).cpu()
-                            elif self.vocoder_name == "bigvgan":
-                                gen_audio = vocoder(gen_mel_spec).squeeze(0).cpu()
-                                ref_audio = vocoder(ref_mel_spec).squeeze(0).cpu()
+                        # Switch the unwrapped model to eval so regional compile dispatch
+                        # (which keys on Module.training) routes inference through the eager
+                        # path. Logged samples use cfg_infer-doubled batches and swept
+                        # durations; routing them through the training compile cache would
+                        # exhaust its per-code-object recompile budget and silently push new
+                        # training shapes back to eager while compile is still reported active.
+                        sample_model = self.accelerator.unwrap_model(self.model)
+                        was_training = sample_model.training
+                        sample_model.eval()
+                        try:
+                            with torch.inference_mode(), self.accelerator.autocast():
+                                generated, _ = sample_model.sample(
+                                    cond=mel_spec[0][:ref_audio_len].unsqueeze(0),
+                                    text=infer_text,
+                                    duration=ref_audio_len * 2,
+                                    steps=nfe_step,
+                                    cfg_strength=cfg_strength,
+                                    sway_sampling_coef=sway_sampling_coef,
+                                )
+                                generated = generated.to(torch.float32)
+                                gen_mel_spec = (
+                                    generated[:, ref_audio_len:, :].permute(0, 2, 1).to(self.accelerator.device)
+                                )
+                                ref_mel_spec = batch["mel"][0, :, :ref_audio_len].unsqueeze(0)
+                                if self.vocoder_name == "vocos":
+                                    gen_audio = vocoder.decode(gen_mel_spec).cpu()
+                                    ref_audio = vocoder.decode(ref_mel_spec).cpu()
+                                elif self.vocoder_name == "bigvgan":
+                                    gen_audio = vocoder(gen_mel_spec).squeeze(0).cpu()
+                                    ref_audio = vocoder(ref_mel_spec).squeeze(0).cpu()
 
-                        torchaudio.save(
-                            f"{log_samples_path}/update_{global_update}_gen.wav", gen_audio, target_sample_rate
-                        )
-                        torchaudio.save(
-                            f"{log_samples_path}/update_{global_update}_ref.wav", ref_audio, target_sample_rate
-                        )
-                        self.model.train()
+                            torchaudio.save(
+                                f"{log_samples_path}/update_{global_update}_gen.wav", gen_audio, target_sample_rate
+                            )
+                            torchaudio.save(
+                                f"{log_samples_path}/update_{global_update}_ref.wav", ref_audio, target_sample_rate
+                            )
+                        finally:
+                            sample_model.train(was_training)
 
         self.save_checkpoint(global_update, last=True)
 

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -526,8 +526,12 @@ class Trainer:
         elif isinstance(text, list):
             if len(text) != mel.shape[0]:
                 return "text list size must match the mel batch size"
-            if any(not isinstance(item, str) for item in text):
-                return "text list entries must be strings"
+            if any(
+                not isinstance(item, str)
+                and (not isinstance(item, list) or any(not isinstance(token, str) for token in item))
+                for item in text
+            ):
+                return "text list entries must be strings or lists of strings"
         else:
             return "text must be a tensor or list"
         return None

--- a/src/f5_tts/model/utils.py
+++ b/src/f5_tts/model/utils.py
@@ -58,15 +58,17 @@ def lens_to_mask(t: int["b"], length: int | None = None) -> bool["b n"]:
     return seq[None, :] < t[:, None]
 
 
-def mask_from_start_end_indices(seq_len: int["b"], start: int["b"], end: int["b"]):
-    max_seq_len = seq_len.max().item()
-    seq = torch.arange(max_seq_len, device=start.device).long()
+def mask_from_start_end_indices(seq_len: int["b"], start: int["b"], end: int["b"], length: int | None = None):
+    # Optional explicit length avoids a seq_len.max().item() CPU-GPU sync (graph break under torch.compile).
+    if not exists(length):
+        length = seq_len.max().item()
+    seq = torch.arange(length, device=start.device).long()
     start_mask = seq[None, :] >= start[:, None]
     end_mask = seq[None, :] < end[:, None]
     return start_mask & end_mask
 
 
-def mask_from_frac_lengths(seq_len: int["b"], frac_lengths: float["b"]):
+def mask_from_frac_lengths(seq_len: int["b"], frac_lengths: float["b"], length: int | None = None):
     lengths = (frac_lengths * seq_len).long()
     max_start = seq_len - lengths
 
@@ -74,7 +76,7 @@ def mask_from_frac_lengths(seq_len: int["b"], frac_lengths: float["b"]):
     start = (max_start * rand).long().clamp(min=0)
     end = start + lengths
 
-    return mask_from_start_end_indices(seq_len, start, end)
+    return mask_from_start_end_indices(seq_len, start, end, length=length)
 
 
 def maybe_masked_mean(t: float["b n d"], mask: bool["b n"] = None) -> float["b d"]:

--- a/src/f5_tts/train/README.md
+++ b/src/f5_tts/train/README.md
@@ -91,3 +91,18 @@ Moreover, if you couldn't access W&B and want to log metrics offline, you can se
 ```
 export WANDB_MODE=offline
 ```
+
+## Global masked-mean training
+
+`global_masked_mean=True` computes one masked-frame mean across each distributed
+accumulation window. Accelerate duplicate-padding is disabled for this mode. A
+multi-process dataloader whose batch count is not divisible by process count is
+rejected before preparation instead of replaying real samples or silently
+dropping a tail group. Choose a batch size or explicit dataset policy that
+produces equal per-rank batch counts.
+
+Checkpoint resume restores the update cursor, epoch-addressable sample order, and
+per-process Python, CPU Torch, CUDA, and DataLoader worker-generator state when
+the process count matches the checkpoint. Resuming with a different process count
+fails explicitly because sampler and RNG trajectories cannot be reconstructed
+safely.

--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -97,6 +97,11 @@ def parse_args():
         action="store_true",
         help="Raise torch.compile errors instead of falling back to eager",
     )
+    parser.add_argument(
+        "--global_masked_mean",
+        action="store_true",
+        help="Weight every masked frame equally across gradient accumulation and DDP",
+    )
     return parser.parse_args()
 
 
@@ -236,6 +241,7 @@ def main():
         compile_fullgraph=args.compile_fullgraph,
         compile_dynamic=compile_dynamic,
         compile_fallback_to_eager=not args.compile_no_fallback,
+        global_masked_mean=args.global_masked_mean,
     )
 
     train_dataset = load_dataset(args.dataset_name, tokenizer, mel_spec_kwargs=mel_spec_kwargs)

--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -71,7 +71,32 @@ def parse_args():
         action="store_true",
         help="Use 8-bit Adam optimizer from bitsandbytes",
     )
-
+    # torch.compile options (optional, default-off)
+    parser.add_argument("--compile_enabled", action="store_true", help="Enable optional torch.compile training path")
+    parser.add_argument("--compile_backend", type=str, default="inductor", help="torch.compile backend")
+    parser.add_argument(
+        "--compile_target",
+        type=str,
+        default="auto",
+        choices=["auto", "cfm_loss_core", "dit_blocks"],
+        help="torch.compile training target (auto chooses a model-compatible target)",
+    )
+    parser.add_argument(
+        "--compile_mode", type=str, default=None, help="torch.compile mode (e.g. default, reduce-overhead)"
+    )
+    parser.add_argument("--compile_fullgraph", action="store_true", help="Require fullgraph torch.compile")
+    parser.add_argument(
+        "--compile_dynamic",
+        type=str,
+        default="default",
+        choices=["default", "true", "false"],
+        help="torch.compile dynamic shape setting (default leaves it unset)",
+    )
+    parser.add_argument(
+        "--compile_no_fallback",
+        action="store_true",
+        help="Raise torch.compile errors instead of falling back to eager",
+    )
     return parser.parse_args()
 
 
@@ -80,6 +105,7 @@ def parse_args():
 
 def main():
     args = parse_args()
+    compile_dynamic = None if args.compile_dynamic == "default" else args.compile_dynamic == "true"
 
     checkpoint_path = str(files("f5_tts").joinpath(f"../../ckpts/{args.dataset_name}"))
 
@@ -179,6 +205,9 @@ def main():
         mel_spec_kwargs=mel_spec_kwargs,
         vocab_char_map=vocab_char_map,
     )
+    compile_target = args.compile_target
+    if compile_target == "auto":
+        compile_target = "dit_blocks" if hasattr(model.transformer, "compile_training_target") else "cfm_loss_core"
 
     trainer = Trainer(
         model,
@@ -200,6 +229,13 @@ def main():
         log_samples=args.log_samples,
         last_per_updates=args.last_per_updates,
         bnb_optimizer=args.bnb_optimizer,
+        compile_enabled=args.compile_enabled,
+        compile_backend=args.compile_backend,
+        compile_target=compile_target,
+        compile_mode=args.compile_mode,
+        compile_fullgraph=args.compile_fullgraph,
+        compile_dynamic=compile_dynamic,
+        compile_fallback_to_eager=not args.compile_no_fallback,
     )
 
     train_dataset = load_dataset(args.dataset_name, tokenizer, mel_spec_kwargs=mel_spec_kwargs)

--- a/src/f5_tts/train/train.py
+++ b/src/f5_tts/train/train.py
@@ -80,6 +80,7 @@ def main(model_cfg):
         compile_fullgraph=compile_cfg.get("fullgraph", False),
         compile_dynamic=compile_cfg.get("dynamic", None),
         compile_fallback_to_eager=compile_cfg.get("fallback_to_eager", True),
+        global_masked_mean=model_cfg.optim.get("global_masked_mean", False),
     )
 
     train_dataset = load_dataset(model_cfg.datasets.name, tokenizer, mel_spec_kwargs=model_cfg.model.mel_spec)

--- a/src/f5_tts/train/train.py
+++ b/src/f5_tts/train/train.py
@@ -27,6 +27,9 @@ def main(model_cfg):
         f"{model_cfg.model.name}_{mel_spec_type}_{model_cfg.model.tokenizer}_{model_cfg.datasets.name}",
     )
     wandb_resume_id = model_cfg.ckpts.get("wandb_resume_id", None)
+    # `or {}` (not a `get` default) so an explicit `compile: null` in a user's config
+    # behaves like an absent block instead of raising AttributeError on the first lookup.
+    compile_cfg = model_cfg.get("compile") or {}
 
     # set text tokenizer
     if tokenizer != "custom":
@@ -41,6 +44,9 @@ def main(model_cfg):
         mel_spec_kwargs=model_cfg.model.mel_spec,
         vocab_char_map=vocab_char_map,
     )
+    compile_target = compile_cfg.get("target", None)
+    if compile_target in (None, "auto"):
+        compile_target = "dit_blocks" if hasattr(model.transformer, "compile_training_target") else "cfm_loss_core"
 
     # init trainer
     trainer = Trainer(
@@ -67,6 +73,13 @@ def main(model_cfg):
         is_local_vocoder=model_cfg.model.vocoder.is_local,
         local_vocoder_path=model_cfg.model.vocoder.local_path,
         model_cfg_dict=OmegaConf.to_container(model_cfg, resolve=True),
+        compile_enabled=compile_cfg.get("enabled", False),
+        compile_backend=compile_cfg.get("backend", "inductor"),
+        compile_target=compile_target,
+        compile_mode=compile_cfg.get("mode", None),
+        compile_fullgraph=compile_cfg.get("fullgraph", False),
+        compile_dynamic=compile_cfg.get("dynamic", None),
+        compile_fallback_to_eager=compile_cfg.get("fallback_to_eager", True),
     )
 
     train_dataset = load_dataset(model_cfg.datasets.name, tokenizer, mel_spec_kwargs=model_cfg.model.mel_spec)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Keep validation tests independent of audio frontend binary packages.
+
+The tests exercise tensor-only CFM/Trainer helpers. Some developer machines do
+not have a torchaudio wheel matching their CUDA build, and librosa can be
+present with an incompatible numba/numpy pair. Minimal import stubs prevent
+those unrelated optional frontends from blocking collection; no stubbed
+function is called by this suite.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+try:
+    import torchaudio  # noqa: F401
+except (ImportError, OSError):
+    torchaudio_stub = types.ModuleType("torchaudio")
+    torchaudio_stub.transforms = types.SimpleNamespace()
+    torchaudio_stub.load = lambda *args, **kwargs: None
+    torchaudio_stub.save = lambda *args, **kwargs: None
+    sys.modules["torchaudio"] = torchaudio_stub
+
+
+try:
+    from librosa.filters import mel as _librosa_mel  # noqa: F401
+except (ImportError, AttributeError):
+    sys.modules.pop("librosa", None)
+    sys.modules.pop("librosa.filters", None)
+    librosa_stub = types.ModuleType("librosa")
+    librosa_stub.__path__ = []
+    librosa_filters_stub = types.ModuleType("librosa.filters")
+    librosa_filters_stub.mel = lambda *args, **kwargs: None
+    librosa_stub.filters = librosa_filters_stub
+    sys.modules["librosa"] = librosa_stub
+    sys.modules["librosa.filters"] = librosa_filters_stub

--- a/tests/test_global_masked_mean_adversarial.py
+++ b/tests/test_global_masked_mean_adversarial.py
@@ -1,0 +1,572 @@
+"""Adversarial reference tests for accumulation-wide masked-mean training.
+
+This is intentionally a validation-branch harness, not an upstream unit test.
+It provides an independent, tiny-model oracle for the training-loop contract:
+
+* denominators are counted exactly before any backward call;
+* every numerator is scaled before backward;
+* a partial final accumulation window still performs exactly one update;
+* an all-empty window performs no optimizer/scheduler/EMA update;
+* DeepSpeed may consume/partition/clear gradients inside ``backward``;
+* the result matches one concatenated global masked-mean batch.
+
+Production integration should replace ``_pre_backward_update`` with the F5-TTS
+window helper while retaining ``_concatenated_reference_update`` as the oracle.
+No F5-TTS model import is needed, keeping the harness CPU/gloo safe.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import tempfile
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+
+
+@dataclass(frozen=True)
+class _Batch:
+    x: torch.Tensor
+    target: torch.Tensor
+    mask: torch.Tensor
+
+    @property
+    def denominator(self) -> torch.Tensor:
+        return self.mask.count_nonzero().to(dtype=torch.int64)
+
+
+@dataclass(frozen=True)
+class _UpdateResult:
+    optimizer_steps: int
+    scheduler_steps: int
+    ema_steps: int
+    skipped: bool
+
+
+class _CountingSGD(torch.optim.SGD):
+    def __init__(self, params, **kwargs):
+        super().__init__(params, **kwargs)
+        self.step_count = 0
+
+    def step(self, closure=None):
+        self.step_count += 1
+        return super().step(closure)
+
+
+class _CountingScheduler:
+    def __init__(self):
+        self.step_count = 0
+
+    def step(self):
+        self.step_count += 1
+
+
+class _CountingEMA:
+    def __init__(self):
+        self.step_count = 0
+
+    def update(self):
+        self.step_count += 1
+
+
+def _make_model() -> nn.Linear:
+    model = nn.Linear(2, 1, bias=True)
+    with torch.no_grad():
+        model.weight.copy_(torch.tensor([[0.25, -0.5]]))
+        model.bias.copy_(torch.tensor([0.125]))
+    return model
+
+
+def _make_batches(mask_counts: Sequence[int]) -> list[_Batch]:
+    batches = []
+    cursor = 0
+    for batch_index, count in enumerate(mask_counts):
+        # Leave at least one unselected item so a mean-of-means implementation
+        # cannot accidentally pass all parameterizations.
+        size = max(count + 1, 2)
+        values = torch.arange(cursor, cursor + size * 2, dtype=torch.float64).reshape(size, 2)
+        x = ((values % 11) - 5.0) / 4.0
+        target = (0.3 * x[:, :1]) - (0.2 * x[:, 1:]) + (batch_index + 1) * 0.17
+        mask = torch.zeros(size, dtype=torch.bool)
+        mask[:count] = True
+        batches.append(_Batch(x=x, target=target, mask=mask))
+        cursor += size * 2
+    return batches
+
+
+def _loss_sum(model: nn.Module, batch: _Batch) -> torch.Tensor:
+    residual = model(batch.x) - batch.target
+    return residual.square().squeeze(-1).masked_fill(~batch.mask, 0.0).sum()
+
+
+def _exact_denominator(batches: Iterable[_Batch]) -> torch.Tensor:
+    counts = [batch.denominator for batch in batches]
+    if not counts:
+        return torch.zeros((), dtype=torch.int64)
+    total = torch.stack(counts).sum(dtype=torch.int64)
+    if total < 0:  # defensive contract for a future externally supplied count
+        raise ValueError("masked-element denominator cannot be negative")
+    return total
+
+
+def _pre_backward_update(
+    model: nn.Module,
+    batches: Sequence[_Batch],
+    *,
+    gradient_accumulation_steps: int,
+    optimizer: _CountingSGD,
+    scheduler: _CountingScheduler,
+    ema: _CountingEMA,
+    max_grad_norm: float | None = None,
+) -> _UpdateResult:
+    """Candidate window algorithm with Accelerate's configured-G division.
+
+    The buffered data contain no autograd graph. Only after the exact denominator
+    is known do we run one forward/backward per microbatch.
+    """
+    if gradient_accumulation_steps < 1:
+        raise ValueError("gradient_accumulation_steps must be positive")
+    if len(batches) > gradient_accumulation_steps:
+        raise ValueError("one update cannot contain more than one accumulation window")
+
+    denominator = _exact_denominator(batches)
+    if int(denominator) == 0:
+        optimizer.zero_grad(set_to_none=True)
+        return _UpdateResult(optimizer.step_count, scheduler.step_count, ema.step_count, skipped=True)
+
+    # Accelerate divides non-DeepSpeed losses by the configured accumulation
+    # count even for a short final window. Multiplying before backward cancels
+    # that division. Crucially, it occurs before clipping or optimizer.step.
+    scale = torch.tensor(
+        gradient_accumulation_steps / int(denominator),
+        dtype=next(model.parameters()).dtype,
+    )
+    for batch in batches:
+        scaled_loss = _loss_sum(model, batch) * scale
+        (scaled_loss / gradient_accumulation_steps).backward()
+
+    if max_grad_norm is not None:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
+    optimizer.step()
+    scheduler.step()
+    ema.update()
+    optimizer.zero_grad(set_to_none=True)
+    return _UpdateResult(optimizer.step_count, scheduler.step_count, ema.step_count, skipped=False)
+
+
+def _concatenated_reference_update(
+    model: nn.Module,
+    batches: Sequence[_Batch],
+    *,
+    optimizer: _CountingSGD,
+    scheduler: _CountingScheduler,
+    ema: _CountingEMA,
+    max_grad_norm: float | None = None,
+) -> _UpdateResult:
+    denominator = _exact_denominator(batches)
+    if int(denominator) == 0:
+        optimizer.zero_grad(set_to_none=True)
+        return _UpdateResult(optimizer.step_count, scheduler.step_count, ema.step_count, skipped=True)
+
+    loss = torch.stack([_loss_sum(model, batch) for batch in batches]).sum() / int(denominator)
+    loss.backward()
+    if max_grad_norm is not None:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
+    optimizer.step()
+    scheduler.step()
+    ema.update()
+    optimizer.zero_grad(set_to_none=True)
+    return _UpdateResult(optimizer.step_count, scheduler.step_count, ema.step_count, skipped=False)
+
+
+def _run_pair(
+    mask_counts: Sequence[int],
+    *,
+    gradient_accumulation_steps: int,
+    max_grad_norm: float | None = None,
+    weight_decay: float = 0.0,
+):
+    batches = _make_batches(mask_counts)
+    candidate = _make_model().double()
+    reference = _make_model().double()
+    reference.load_state_dict(candidate.state_dict())
+
+    candidate_optimizer = _CountingSGD(candidate.parameters(), lr=0.03, momentum=0.8, weight_decay=weight_decay)
+    reference_optimizer = _CountingSGD(reference.parameters(), lr=0.03, momentum=0.8, weight_decay=weight_decay)
+    candidate_scheduler, reference_scheduler = _CountingScheduler(), _CountingScheduler()
+    candidate_ema, reference_ema = _CountingEMA(), _CountingEMA()
+
+    candidate_result = _pre_backward_update(
+        candidate,
+        batches,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+        optimizer=candidate_optimizer,
+        scheduler=candidate_scheduler,
+        ema=candidate_ema,
+        max_grad_norm=max_grad_norm,
+    )
+    reference_result = _concatenated_reference_update(
+        reference,
+        batches,
+        optimizer=reference_optimizer,
+        scheduler=reference_scheduler,
+        ema=reference_ema,
+        max_grad_norm=max_grad_norm,
+    )
+    return candidate, reference, candidate_result, reference_result
+
+
+@pytest.mark.parametrize(
+    "mask_counts,gradient_accumulation_steps",
+    [
+        ([3], 1),  # G=1
+        ([1, 5, 2, 7], 4),  # full window, unequal microbatch counts
+        ([0, 4, 1], 4),  # partial final window with one empty microbatch
+        ([2, 6], 8),  # entire dataloader shorter than configured G
+    ],
+)
+def test_pre_backward_window_matches_concatenated_parameter_update(mask_counts, gradient_accumulation_steps):
+    candidate, reference, candidate_result, reference_result = _run_pair(
+        mask_counts, gradient_accumulation_steps=gradient_accumulation_steps
+    )
+
+    torch.testing.assert_close(candidate.weight, reference.weight, atol=1e-12, rtol=1e-12)
+    torch.testing.assert_close(candidate.bias, reference.bias, atol=1e-12, rtol=1e-12)
+    assert candidate_result == reference_result == _UpdateResult(1, 1, 1, skipped=False)
+
+
+def test_normalization_precedes_gradient_clipping():
+    candidate, reference, candidate_result, reference_result = _run_pair(
+        [1, 17, 2],
+        gradient_accumulation_steps=4,
+        max_grad_norm=0.08,
+    )
+
+    torch.testing.assert_close(candidate.weight, reference.weight, atol=1e-12, rtol=1e-12)
+    torch.testing.assert_close(candidate.bias, reference.bias, atol=1e-12, rtol=1e-12)
+    assert candidate_result == reference_result == _UpdateResult(1, 1, 1, skipped=False)
+
+
+def test_all_zero_window_skips_weight_decay_optimizer_scheduler_and_ema():
+    candidate, reference, candidate_result, reference_result = _run_pair(
+        [0, 0],
+        gradient_accumulation_steps=4,
+        weight_decay=0.2,
+    )
+
+    torch.testing.assert_close(candidate.weight, reference.weight, atol=0, rtol=0)
+    torch.testing.assert_close(candidate.bias, reference.bias, atol=0, rtol=0)
+    assert candidate_result == reference_result == _UpdateResult(0, 0, 0, skipped=True)
+    assert all(parameter.grad is None for parameter in candidate.parameters())
+
+
+def test_denominator_remains_exact_beyond_float32_integer_range():
+    counts = torch.tensor([2**24, 1, 9], dtype=torch.int64)
+    exact = counts.sum(dtype=torch.int64)
+    lossy = counts.to(dtype=torch.float32).sum()
+
+    assert exact.dtype == torch.int64
+    assert int(exact) == 2**24 + 10
+    assert int(lossy) != int(exact)
+
+
+@pytest.mark.parametrize("gradient_accumulation_steps", [0, -1])
+def test_invalid_accumulation_count_fails_before_backward(gradient_accumulation_steps):
+    model = _make_model().double()
+    optimizer = _CountingSGD(model.parameters(), lr=0.1)
+    with pytest.raises(ValueError, match="must be positive"):
+        _pre_backward_update(
+            model,
+            _make_batches([1]),
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            optimizer=optimizer,
+            scheduler=_CountingScheduler(),
+            ema=_CountingEMA(),
+        )
+    assert optimizer.step_count == 0
+    assert all(parameter.grad is None for parameter in model.parameters())
+
+
+def test_oversized_window_fails_instead_of_silently_changing_update_boundaries():
+    model = _make_model().double()
+    optimizer = _CountingSGD(model.parameters(), lr=0.1)
+    with pytest.raises(ValueError, match="more than one accumulation window"):
+        _pre_backward_update(
+            model,
+            _make_batches([1, 2, 3]),
+            gradient_accumulation_steps=2,
+            optimizer=optimizer,
+            scheduler=_CountingScheduler(),
+            ema=_CountingEMA(),
+        )
+    assert optimizer.step_count == 0
+
+
+@pytest.mark.parametrize("backend", ["eager", "inductor"])
+def test_compiled_loss_sum_keeps_window_normalization_outside_graph(backend):
+    if backend == "inductor":
+        pytest.importorskip("torch._inductor")
+    if not hasattr(torch, "compile"):
+        pytest.skip("torch.compile is unavailable")
+
+    class _LossCore(nn.Module):
+        def forward(self, prediction, target, mask):
+            return (prediction.sub(target).square() * mask[:, None]).sum()
+
+    batches = _make_batches([1, 5, 2])
+    eager_model = _make_model().double()
+    compiled_model = _make_model().double()
+    compiled_model.load_state_dict(eager_model.state_dict())
+    eager_optimizer = _CountingSGD(eager_model.parameters(), lr=0.03)
+    compiled_optimizer = _CountingSGD(compiled_model.parameters(), lr=0.03)
+    compiled_core = torch.compile(_LossCore(), backend=backend, fullgraph=True, dynamic=True)
+    denominator = _exact_denominator(batches)
+
+    for batch in batches:
+        (_loss_sum(eager_model, batch) / int(denominator)).backward()
+        compiled_sum = compiled_core(compiled_model(batch.x), batch.target, batch.mask)
+        (compiled_sum / int(denominator)).backward()
+    eager_optimizer.step()
+    compiled_optimizer.step()
+
+    torch.testing.assert_close(compiled_model.weight, eager_model.weight, atol=1e-10, rtol=1e-10)
+    torch.testing.assert_close(compiled_model.bias, eager_model.bias, atol=1e-10, rtol=1e-10)
+
+
+class _DeepSpeedEngineMock:
+    """Small semantic mock of the engine boundary contract, not ZeRO internals."""
+
+    def __init__(self, model: nn.Module, *, gradient_accumulation_steps: int):
+        self.model = model
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.optimizer = _CountingSGD(model.parameters(), lr=0.03)
+        self.boundary_override: bool | None = None
+        self.micro_steps = 0
+        self.step_calls = 0
+        self.actual_updates = 0
+        self.boundary_events: list[bool] = []
+
+    def set_gradient_accumulation_boundary(self, is_boundary: bool):
+        self.boundary_override = is_boundary
+        self.boundary_events.append(is_boundary)
+
+    def backward(self, loss: torch.Tensor):
+        # DeepSpeed owns configured-G loss scaling.
+        (loss / self.gradient_accumulation_steps).backward()
+
+    def step(self):
+        self.step_calls += 1
+        default_boundary = (self.micro_steps + 1) % self.gradient_accumulation_steps == 0
+        boundary = default_boundary if self.boundary_override is None else self.boundary_override
+        self.micro_steps += 1
+        if not boundary:
+            return
+        self.optimizer.step()
+        self.optimizer.zero_grad(set_to_none=True)
+        self.actual_updates += 1
+
+
+class _Accelerate033DeepSpeedWrapperMock:
+    """Accelerate 0.33: backward always invokes engine.step()."""
+
+    def __init__(self, engine: _DeepSpeedEngineMock):
+        self.engine = engine
+
+    def backward(self, loss: torch.Tensor, *, sync_gradients: bool):
+        del sync_gradients
+        self.engine.backward(loss)
+        self.engine.step()
+
+
+class _AccelerateCurrentDeepSpeedWrapperMock:
+    """Accelerate 1.14: boundary follows sync_gradients and step is conditional."""
+
+    def __init__(self, engine: _DeepSpeedEngineMock):
+        self.engine = engine
+
+    def backward(self, loss: torch.Tensor, *, sync_gradients: bool):
+        self.engine.set_gradient_accumulation_boundary(is_boundary=sync_gradients)
+        self.engine.backward(loss)
+        if sync_gradients:
+            self.engine.step()
+
+
+def _deepspeed_pre_backward_update(wrapper, batches: Sequence[_Batch], *, gradient_accumulation_steps: int):
+    engine = wrapper.engine
+    denominator = _exact_denominator(batches)
+    if int(denominator) == 0:
+        return
+    scale = gradient_accumulation_steps / int(denominator)
+    for index, batch in enumerate(batches):
+        is_boundary = index == len(batches) - 1
+        # The explicit engine boundary is required for a partial window under
+        # Accelerate 0.33; current Accelerate sets the same value again.
+        engine.set_gradient_accumulation_boundary(is_boundary=is_boundary)
+        wrapper.backward(_loss_sum(engine.model, batch) * scale, sync_gradients=is_boundary)
+
+
+@pytest.mark.parametrize(
+    "wrapper_type,expected_step_calls",
+    [
+        (_Accelerate033DeepSpeedWrapperMock, 2),
+        (_AccelerateCurrentDeepSpeedWrapperMock, 1),
+    ],
+    ids=["accelerate-0.33", "accelerate-current"],
+)
+def test_deepspeed_boundary_adapter_flushes_partial_window_once(wrapper_type, expected_step_calls):
+    batches = _make_batches([1, 6])
+    candidate = _make_model().double()
+    reference = _make_model().double()
+    reference.load_state_dict(candidate.state_dict())
+    engine = _DeepSpeedEngineMock(candidate, gradient_accumulation_steps=4)
+
+    _deepspeed_pre_backward_update(wrapper_type(engine), batches, gradient_accumulation_steps=4)
+    _concatenated_reference_update(
+        reference,
+        batches,
+        optimizer=_CountingSGD(reference.parameters(), lr=0.03),
+        scheduler=_CountingScheduler(),
+        ema=_CountingEMA(),
+    )
+
+    assert engine.actual_updates == 1
+    assert engine.step_calls == expected_step_calls
+    assert engine.boundary_events[-1] is True
+    torch.testing.assert_close(candidate.weight, reference.weight, atol=1e-12, rtol=1e-12)
+    torch.testing.assert_close(candidate.bias, reference.bias, atol=1e-12, rtol=1e-12)
+
+
+def test_post_backward_gradient_scaling_is_too_late_for_deepspeed_step():
+    batches = _make_batches([1, 7])
+    broken = _make_model().double()
+    reference = _make_model().double()
+    reference.load_state_dict(broken.state_dict())
+    engine = _DeepSpeedEngineMock(broken, gradient_accumulation_steps=2)
+    wrapper = _AccelerateCurrentDeepSpeedWrapperMock(engine)
+    denominator = _exact_denominator(batches)
+
+    # Reproduce the rejected design: backward raw sums and mutate .grad only
+    # after the boundary backward. Current Accelerate has already called
+    # engine.step() and DeepSpeed has cleared the gradients at that point.
+    for index, batch in enumerate(batches):
+        wrapper.backward(_loss_sum(broken, batch), sync_gradients=index == len(batches) - 1)
+    for parameter in broken.parameters():
+        if parameter.grad is not None:
+            parameter.grad.mul_(2 / int(denominator))
+
+    _concatenated_reference_update(
+        reference,
+        batches,
+        optimizer=_CountingSGD(reference.parameters(), lr=0.03),
+        scheduler=_CountingScheduler(),
+        ema=_CountingEMA(),
+    )
+
+    assert engine.actual_updates == 1
+    assert all(parameter.grad is None for parameter in broken.parameters())
+    with pytest.raises(AssertionError):
+        torch.testing.assert_close(broken.weight, reference.weight, atol=1e-12, rtol=1e-12)
+
+
+def test_no_autograd_graph_is_created_while_precomputing_denominator():
+    batches = _make_batches([1, 3, 2])
+    for batch in batches:
+        batch.x.requires_grad_(True)
+
+    denominator = _exact_denominator(batches)
+
+    assert denominator.dtype == torch.int64
+    assert denominator.grad_fn is None
+    assert all(batch.x.grad_fn is None and batch.x.grad is None for batch in batches)
+
+
+def _ddp_case(rank: int, world_size: int, *, gradient_accumulation_steps: int, rank_counts):
+    local_batches = _make_batches(rank_counts[rank])
+    model = _make_model().double()
+    ddp_model = DistributedDataParallel(model)
+    optimizer = _CountingSGD(ddp_model.parameters(), lr=0.03, momentum=0.8)
+
+    local_denominator = _exact_denominator(local_batches)
+    global_denominator = local_denominator.clone()
+    dist.all_reduce(global_denominator, op=dist.ReduceOp.SUM)
+    assert global_denominator.dtype == torch.int64
+    assert int(global_denominator) > 0
+
+    for index, batch in enumerate(local_batches):
+        is_boundary = index == len(local_batches) - 1
+        sync_context = contextlib.nullcontext() if is_boundary else ddp_model.no_sync()
+        with sync_context:
+            # Accelerate divides by configured G; DDP averages by world size.
+            # Both are cancelled before backward.
+            loss = _loss_sum(ddp_model, batch)
+            scaled_loss = loss * gradient_accumulation_steps * world_size / int(global_denominator)
+            (scaled_loss / gradient_accumulation_steps).backward()
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+
+    # Independent global-batch oracle uses every rank's data in one process.
+    reference = _make_model().double()
+    reference_optimizer = _CountingSGD(reference.parameters(), lr=0.03, momentum=0.8)
+    global_batches = [batch for counts in rank_counts for batch in _make_batches(counts)]
+    _concatenated_reference_update(
+        reference,
+        global_batches,
+        optimizer=reference_optimizer,
+        scheduler=_CountingScheduler(),
+        ema=_CountingEMA(),
+    )
+
+    torch.testing.assert_close(model.weight, reference.weight, atol=1e-12, rtol=1e-12)
+    torch.testing.assert_close(model.bias, reference.bias, atol=1e-12, rtol=1e-12)
+
+    # Detect rank divergence even if both ranks happened to miss the oracle in
+    # the same way. This also catches an unmatched final reduction boundary.
+    flattened = torch.cat([model.weight.detach().reshape(-1), model.bias.detach().reshape(-1)])
+    gathered = [torch.empty_like(flattened) for _ in range(world_size)]
+    dist.all_gather(gathered, flattened)
+    for peer in gathered:
+        torch.testing.assert_close(flattened, peer, atol=0, rtol=0)
+
+
+def _ddp_worker(rank: int, world_size: int, init_method: str):
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+        timeout=datetime.timedelta(seconds=30),
+    )
+    try:
+        # Full G=2 window with unequal counts and one empty microbatch.
+        _ddp_case(
+            rank,
+            world_size,
+            gradient_accumulation_steps=2,
+            rank_counts=((1, 0), (4, 2)),
+        )
+        dist.barrier()
+        # Partial R=2 < G=4 window where rank 0 selects nothing at all.
+        _ddp_case(
+            rank,
+            world_size,
+            gradient_accumulation_steps=4,
+            rank_counts=((0, 0), (5, 1)),
+        )
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="gloo backend unavailable")
+def test_two_rank_gloo_matches_global_batch_for_full_partial_and_zero_local_denominator():
+    with tempfile.TemporaryDirectory(prefix="f5-global-mean-gloo-") as tmpdir:
+        init_method = f"file://{tmpdir}/store"
+        mp.spawn(_ddp_worker, args=(2, init_method), nprocs=2, join=True)

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -258,6 +258,28 @@ def test_window_iterator_uses_int64_denominator_tensor_and_exact_boundaries():
     assert [value.dtype for value in trainer.accelerator.reduced] == [torch.int64, torch.int64]
 
 
+def test_window_iterator_accepts_preprocessed_pinyin_token_lists():
+    mask = torch.tensor([[True, True, False]])
+    trainer = _iterator_trainer([mask], gradient_accumulation_steps=1)
+    batch = _batch(mel_channels=2, seq_len=3)
+    batch["text"] = [[" ", "ni3", "hao3"]]
+
+    [yielded] = list(trainer._iter_global_masked_mean_batches([batch]))
+
+    assert yielded[0] is batch
+    assert yielded[1] is mask
+    assert yielded[4] is True
+
+
+def test_window_iterator_rejects_non_string_preprocessed_text_tokens():
+    trainer = _iterator_trainer([torch.ones((1, 3), dtype=torch.bool)], gradient_accumulation_steps=1)
+    batch = _batch(mel_channels=2, seq_len=3)
+    batch["text"] = [["ni3", 3]]
+
+    with pytest.raises(ValueError, match="strings or lists of strings"):
+        list(trainer._iter_global_masked_mean_batches([batch]))
+
+
 def test_window_scale_includes_configured_g_and_data_parallel_world_size():
     masks = [torch.tensor([[True, True, False]])]
     trainer = _iterator_trainer(

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -1,0 +1,669 @@
+"""Direct contract tests for the F5-TTS global masked-mean implementation."""
+
+from __future__ import annotations
+
+import datetime
+import random
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from accelerate.data_loader import BatchSamplerShard
+from accelerate.utils import DistributedType
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+
+from f5_tts.model.cfm import CFM
+from f5_tts.model.dataset import DynamicBatchSampler
+from f5_tts.model.trainer import Trainer
+
+
+class _DummyMelSpec(nn.Module):
+    n_mel_channels = 2
+    target_sample_rate = 24_000
+    hop_length = 256
+
+    def forward(self, wav):  # pragma: no cover - all contract inputs are mel tensors
+        raise AssertionError("audio frontend must not run")
+
+
+class _TinyTransformer(nn.Module):
+    dim = 2
+
+    def __init__(self):
+        super().__init__()
+        self.gain = nn.Parameter(torch.tensor(0.75))
+
+    def forward(self, *, x, **kwargs):
+        return x * self.gain
+
+
+def _tiny_cfm() -> CFM:
+    return CFM(
+        _TinyTransformer(),
+        num_channels=2,
+        mel_spec_module=_DummyMelSpec(),
+        frac_lengths_mask=(0.5, 0.5),
+        audio_drop_prob=0.0,
+        cond_drop_prob=0.0,
+    )
+
+
+def test_sample_training_mask_is_boolean_and_never_selects_padding():
+    model = _tiny_cfm()
+    lens = torch.tensor([5, 2], dtype=torch.int32)
+
+    mask = model.sample_training_mask(lens, seq_len=6)
+
+    assert mask.shape == (2, 6)
+    assert mask.dtype == torch.bool
+    assert mask.device == model.device
+    assert not mask[0, 5]
+    assert not mask[1, 2:].any()
+
+
+@pytest.mark.parametrize(
+    "lens,seq_len,message",
+    [
+        (torch.tensor([-1, 2]), 4, "between 0 and seq_len"),
+        (torch.tensor([5, 2]), 4, "between 0 and seq_len"),
+        (torch.tensor([1, 2]), -1, "seq_len must be non-negative"),
+    ],
+    ids=["negative-length", "length-exceeds-sequence", "negative-sequence-length"],
+)
+def test_sample_training_mask_rejects_invalid_length_bounds(lens, seq_len, message):
+    model = _tiny_cfm()
+
+    with pytest.raises(ValueError, match=message):
+        model.sample_training_mask(lens, seq_len)
+
+
+def test_forward_reuses_presampled_mask_without_resampling(monkeypatch):
+    model = _tiny_cfm()
+    inp = torch.arange(16, dtype=torch.float32).reshape(2, 4, 2) / 8
+    text = torch.tensor([[1, 2], [3, 4]])
+    lens = torch.tensor([3, 1])
+    # Padded selections must be removed by the valid-length mask.
+    presampled = torch.ones((2, 4), dtype=torch.bool)
+
+    def fail_if_resampled(*args, **kwargs):
+        raise AssertionError("forward resampled a precomputed training mask")
+
+    monkeypatch.setattr(model, "_sample_training_mask", fail_if_resampled)
+    loss, loss_sum, denominator, _, _ = model(
+        inp,
+        text,
+        lens=lens,
+        rand_span_mask=presampled,
+        return_loss_components=True,
+    )
+
+    # Four valid time positions, two mel channels each.
+    assert denominator == 8
+    torch.testing.assert_close(loss, loss_sum / 8)
+
+
+@pytest.mark.skipif(not hasattr(torch, "compile"), reason="torch.compile unavailable")
+def test_presampled_mask_matches_with_production_compile_entrypoint():
+    eager = _tiny_cfm()
+    compiled = _tiny_cfm()
+    compiled.load_state_dict(eager.state_dict())
+    compiled.compile_training_core(backend="eager", fullgraph=True, dynamic=True)
+    inp = torch.arange(16, dtype=torch.float32).reshape(2, 4, 2) / 8
+    text = torch.tensor([[1, 2], [3, 4]])
+    lens = torch.tensor([4, 3])
+    mask = torch.tensor(
+        [
+            [True, False, True, False],
+            [False, True, True, False],
+        ]
+    )
+
+    torch.manual_seed(901)
+    random.seed(901)
+    eager_loss, eager_sum, eager_denom, _, _ = eager(
+        inp,
+        text,
+        lens=lens,
+        rand_span_mask=mask,
+        return_loss_components=True,
+    )
+    eager_loss.backward()
+    torch.manual_seed(901)
+    random.seed(901)
+    compiled_loss, compiled_sum, compiled_denom, _, _ = compiled(
+        inp,
+        text,
+        lens=lens,
+        rand_span_mask=mask,
+        return_loss_components=True,
+    )
+    compiled_loss.backward()
+
+    torch.testing.assert_close(compiled_loss, eager_loss)
+    torch.testing.assert_close(compiled_sum, eager_sum)
+    torch.testing.assert_close(compiled_denom, eager_denom)
+    torch.testing.assert_close(compiled.transformer.gain.grad, eager.transformer.gain.grad)
+
+
+def test_forward_rejects_presampled_mask_with_wrong_shape():
+    model = _tiny_cfm()
+    inp = torch.zeros((2, 4, 2))
+    text = torch.tensor([[1], [2]])
+
+    with pytest.raises(ValueError, match=r"rand_span_mask must have shape \(2, 4\)"):
+        model(
+            inp,
+            text,
+            lens=torch.tensor([4, 4]),
+            rand_span_mask=torch.ones((2, 3), dtype=torch.bool),
+            return_loss_components=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_mask",
+    [
+        torch.tensor([[0.0, 1.0], [float("nan"), 0.0]]),
+        torch.tensor([[0, 1], [1, 0]], dtype=torch.int64),
+    ],
+    ids=["float-with-nan", "integer"],
+)
+def test_forward_rejects_non_boolean_presampled_mask(bad_mask):
+    model = _tiny_cfm()
+    inp = torch.zeros((2, 2, 2))
+    text = torch.tensor([[1], [2]])
+
+    with pytest.raises(TypeError, match="rand_span_mask must have dtype torch.bool"):
+        model(
+            inp,
+            text,
+            lens=torch.tensor([2, 2]),
+            rand_span_mask=bad_mask,
+            return_loss_components=True,
+        )
+
+
+class _MaskSampler:
+    def __init__(self, masks):
+        self.masks = iter(masks)
+        self.calls = []
+
+    def sample_training_mask(self, lens, seq_len):
+        self.calls.append((lens.clone(), seq_len))
+        return next(self.masks)
+
+
+class _IteratorAccelerator:
+    def __init__(self, *, num_processes=1, remote_denominator=0):
+        self.device = torch.device("cpu")
+        self.num_processes = num_processes
+        self.remote_denominator = remote_denominator
+        self.reduced = []
+
+    def reduce(self, value, reduction):
+        assert reduction == "sum"
+        self.reduced.append(value.clone())
+        remote = torch.zeros_like(value)
+        if remote.ndim == 0:
+            remote = remote + self.remote_denominator
+        else:
+            remote[0] = self.remote_denominator
+        return value + remote
+
+
+def _batch(*, mel_channels=2, seq_len=5):
+    return {
+        "mel": torch.zeros((1, mel_channels, seq_len)),
+        "mel_lengths": torch.tensor([seq_len]),
+        "text": ["test"],
+    }
+
+
+def _iterator_trainer(masks, *, gradient_accumulation_steps=3, num_processes=1, remote_denominator=0):
+    trainer = Trainer.__new__(Trainer)
+    trainer.grad_accumulation_steps = gradient_accumulation_steps
+    trainer.accelerator = _IteratorAccelerator(
+        num_processes=num_processes,
+        remote_denominator=remote_denominator,
+    )
+    trainer._unwrapped_model = _MaskSampler(masks)
+    return trainer
+
+
+def test_window_iterator_uses_int64_denominator_tensor_and_exact_boundaries():
+    masks = [
+        torch.tensor([[True, False, False, False, False]]),
+        torch.tensor([[True, True, True, False, False]]),
+        torch.tensor([[True, True, False, False, False]]),
+        torch.tensor([[True, True, True, True, False]]),
+        torch.tensor([[True, False, False, False, False]]),
+    ]
+    trainer = _iterator_trainer(masks, gradient_accumulation_steps=3)
+
+    yielded = list(trainer._iter_global_masked_mean_batches([_batch() for _ in masks]))
+
+    assert [entry[4] for entry in yielded] == [False, False, True, False, True]
+    assert [entry[1] for entry in yielded] == masks
+    # Counts are multiplied by two mel channels: first window 12, second 10.
+    assert [int(entry[3]) for entry in yielded] == [12, 12, 12, 10, 10]
+    assert [entry[3].dtype for entry in yielded] == [torch.int64] * 5
+    assert [float(entry[2]) for entry in yielded] == pytest.approx([3 / 12] * 3 + [3 / 10] * 2)
+    assert [value.dtype for value in trainer.accelerator.reduced] == [torch.int64, torch.int64]
+
+
+def test_window_scale_includes_configured_g_and_data_parallel_world_size():
+    masks = [torch.tensor([[True, True, False]])]
+    trainer = _iterator_trainer(
+        masks,
+        gradient_accumulation_steps=4,
+        num_processes=2,
+        remote_denominator=6,
+    )
+
+    [(_, _, loss_scale, global_denominator, is_boundary)] = list(
+        trainer._iter_global_masked_mean_batches([_batch(mel_channels=2, seq_len=3)])
+    )
+
+    # Local denominator 2 tokens * 2 channels = 4; emulated peer contributes 6.
+    assert global_denominator == 10
+    assert loss_scale.dtype == torch.float32
+    assert loss_scale.device == trainer.accelerator.device
+    torch.testing.assert_close(loss_scale, torch.tensor(4 * 2 / 10, dtype=torch.float32))
+    assert is_boundary is True
+
+
+class _NoItemTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, value):
+        return value.as_subclass(cls)
+
+    def item(self):
+        raise AssertionError("denominator path performed a host-synchronizing Tensor.item()")
+
+
+class _NoItemAccelerator(_IteratorAccelerator):
+    def reduce(self, value, reduction):
+        result = super().reduce(value, reduction)
+        return _NoItemTensor(result)
+
+
+def test_window_scale_stays_on_device_without_tensor_item():
+    trainer = _iterator_trainer([torch.tensor([[True, False]])], gradient_accumulation_steps=2)
+    trainer.accelerator = _NoItemAccelerator()
+
+    [entry] = list(trainer._iter_global_masked_mean_batches([_batch(mel_channels=2, seq_len=2)]))
+
+    assert isinstance(entry[2], torch.Tensor)
+    assert entry[2].dtype == torch.float32
+
+
+def test_all_zero_global_denominator_fails_before_yielding_or_backward():
+    trainer = _iterator_trainer(
+        [torch.zeros((1, 3), dtype=torch.bool), torch.zeros((1, 3), dtype=torch.bool)],
+        gradient_accumulation_steps=2,
+    )
+
+    with pytest.raises(RuntimeError, match="empty accumulation window"):
+        list(
+            trainer._iter_global_masked_mean_batches(
+                [_batch(mel_channels=2, seq_len=3), _batch(mel_channels=2, seq_len=3)]
+            )
+        )
+
+
+class _RecordingContext:
+    def __init__(self, events, name):
+        self.events = events
+        self.name = name
+
+    def __enter__(self):
+        self.events.append(f"enter:{self.name}")
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.events.append(f"exit:{self.name}")
+
+
+class _ContextAccelerator:
+    def __init__(self, distributed_type):
+        self.distributed_type = distributed_type
+        self.sync_gradients = True
+        self.events = []
+
+    def accumulate(self, model):
+        return _RecordingContext(self.events, "accumulate")
+
+    def no_sync(self, model):
+        return _RecordingContext(self.events, "no_sync")
+
+
+class _BoundaryModel:
+    def __init__(self, *, gradient_accumulation_steps=4):
+        self.boundaries = []
+        self.dp_world_size = 2
+        self._gradient_accumulation_steps = gradient_accumulation_steps
+
+    def set_gradient_accumulation_boundary(self, is_boundary):
+        self.boundaries.append(is_boundary)
+
+    def gradient_accumulation_steps(self):
+        return self._gradient_accumulation_steps
+
+
+def _context_trainer(distributed_type):
+    trainer = Trainer.__new__(Trainer)
+    trainer.accelerator = _ContextAccelerator(distributed_type)
+    trainer.model = _BoundaryModel()
+    return trainer
+
+
+def test_default_path_keeps_accelerate_automatic_accumulation():
+    trainer = _context_trainer(DistributedType.NO)
+
+    with trainer._accumulation_context(None):
+        trainer.accelerator.events.append("body")
+
+    assert trainer.accelerator.events == ["enter:accumulate", "body", "exit:accumulate"]
+    assert trainer.accelerator.sync_gradients is True
+    assert trainer.model.boundaries == []
+
+
+@pytest.mark.parametrize(
+    "is_boundary,expected_events",
+    [
+        (False, ["enter:no_sync", "body", "exit:no_sync"]),
+        (True, ["body"]),
+    ],
+)
+def test_ddp_explicit_boundary_controls_no_sync(is_boundary, expected_events):
+    trainer = _context_trainer(DistributedType.MULTI_CPU)
+
+    with trainer._accumulation_context(is_boundary):
+        trainer.accelerator.events.append("body")
+
+    assert trainer.accelerator.events == expected_events
+    assert trainer.accelerator.sync_gradients is is_boundary
+    assert trainer.model.boundaries == []
+
+
+@pytest.mark.parametrize("is_boundary", [False, True])
+def test_deepspeed_explicit_boundary_uses_engine_public_api(is_boundary):
+    trainer = _context_trainer(DistributedType.DEEPSPEED)
+
+    with trainer._accumulation_context(is_boundary):
+        trainer.accelerator.events.append("body")
+
+    assert trainer.accelerator.events == ["body"]
+    assert trainer.accelerator.sync_gradients is is_boundary
+    assert trainer.model.boundaries == [is_boundary]
+
+
+def test_context_propagates_body_exception_without_corrupting_boundary_state():
+    trainer = _context_trainer(DistributedType.MULTI_CPU)
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        with trainer._accumulation_context(False):
+            raise RuntimeError("forward failed")
+
+    assert trainer.accelerator.events == ["enter:no_sync", "exit:no_sync"]
+    assert trainer.accelerator.sync_gradients is False
+
+
+class _DeepSpeedPluginStub:
+    def __init__(self, *, zero_stage=0, gradient_clipping=1.0):
+        self.zero_stage = zero_stage
+        self.gradient_clipping = gradient_clipping
+
+    def get_value(self, key):
+        assert key == "gradient_clipping"
+        return self.gradient_clipping
+
+
+class _BackendAccelerator:
+    def __init__(
+        self,
+        *,
+        distributed_type=DistributedType.DEEPSPEED,
+        num_processes=2,
+        gas=4,
+        zero_stage=0,
+    ):
+        self.distributed_type = distributed_type
+        self.num_processes = num_processes
+        self.gradient_accumulation_steps = gas
+        self.state = SimpleNamespace(deepspeed_plugin=_DeepSpeedPluginStub(zero_stage=zero_stage))
+
+
+def _backend_trainer(model=None, *, trainer_gas=4, accelerator_gas=4, zero_stage=0):
+    trainer = Trainer.__new__(Trainer)
+    trainer.global_masked_mean = True
+    trainer.grad_accumulation_steps = trainer_gas
+    trainer.max_grad_norm = 1.0
+    trainer.accelerator = _BackendAccelerator(gas=accelerator_gas, zero_stage=zero_stage)
+    trainer.model = _BoundaryModel(gradient_accumulation_steps=trainer_gas) if model is None else model
+    return trainer
+
+
+def test_deepspeed_backend_validation_accepts_plain_data_parallel_engine():
+    _backend_trainer()._validate_global_masked_mean_backend()
+
+
+def test_deepspeed_backend_validation_requires_public_boundary_api():
+    trainer = _backend_trainer(model=object())
+
+    with pytest.raises(NotImplementedError, match="set_gradient_accumulation_boundary"):
+        trainer._validate_global_masked_mean_backend()
+
+
+@pytest.mark.parametrize("zero_stage", [1, 2, 3])
+def test_deepspeed_backend_validation_rejects_sharded_zero_until_checkpoint_and_ema_are_safe(zero_stage):
+    trainer = _backend_trainer(zero_stage=zero_stage)
+
+    with pytest.raises(NotImplementedError, match="ZeRO stage 0 only"):
+        trainer._validate_global_masked_mean_backend()
+
+
+def test_deepspeed_backend_validation_rejects_nonworld_data_parallel_group():
+    model = _BoundaryModel()
+    model.dp_world_size = 1
+    trainer = _backend_trainer(model=model)
+
+    with pytest.raises(NotImplementedError, match="non-world data-parallel group"):
+        trainer._validate_global_masked_mean_backend()
+
+
+def test_deepspeed_backend_validation_rejects_accumulation_mismatch():
+    trainer = _backend_trainer(trainer_gas=4, accelerator_gas=2)
+
+    with pytest.raises(ValueError, match="Accelerator and Trainer gradient accumulation"):
+        trainer._validate_global_masked_mean_backend()
+
+
+class _GatherAccelerator:
+    def __init__(self, gathered_lengths):
+        self.device = torch.device("cpu")
+        self.gathered_lengths = torch.tensor(gathered_lengths, dtype=torch.int64)
+
+    def gather(self, value):
+        assert value.dtype == torch.int64
+        return self.gathered_lengths.to(value.device)
+
+
+def test_global_dataloader_validation_accepts_equal_rank_lengths():
+    trainer = Trainer.__new__(Trainer)
+    trainer.accelerator = _GatherAccelerator([7, 7])
+
+    trainer._validate_global_masked_dataloader(range(7))
+
+
+def test_global_dataloader_validation_rejects_unequal_rank_lengths_collectively():
+    trainer = Trainer.__new__(Trainer)
+    trainer.accelerator = _GatherAccelerator([7, 6])
+
+    with pytest.raises(RuntimeError, match=r"per-rank lengths \[7, 6\]"):
+        trainer._validate_global_masked_dataloader(range(7))
+
+
+@pytest.mark.parametrize("num_processes", [2, 3])
+@pytest.mark.parametrize("num_dynamic_batches", range(1, 8))
+def test_dynamic_batch_sampler_drop_last_gives_every_rank_equal_batch_count(
+    num_processes,
+    num_dynamic_batches,
+):
+    # DynamicBatchSampler intentionally advertises drop_last=True to
+    # BatchSamplerShard even when it retained its own residual sample batch.
+    # Accelerate then drops only the final incomplete *group of rank batches*.
+    sampler = DynamicBatchSampler.__new__(DynamicBatchSampler)
+    sampler.batches = [[index] for index in range(num_dynamic_batches)]
+    sampler.drop_last = True
+    sampler.random_seed = None
+    sampler.epoch = 0
+
+    shards = [
+        BatchSamplerShard(
+            sampler,
+            num_processes=num_processes,
+            process_index=rank,
+            split_batches=False,
+            even_batches=False,
+        )
+        for rank in range(num_processes)
+    ]
+    per_rank_batches = [list(shard) for shard in shards]
+
+    assert {len(batches) for batches in per_rank_batches} == {num_dynamic_batches // num_processes}
+    assert {len(shard) for shard in shards} == {num_dynamic_batches // num_processes}
+
+
+class _DirectDDPAccelerator:
+    def __init__(self, *, world_size, gradient_accumulation_steps):
+        self.device = torch.device("cpu")
+        self.num_processes = world_size
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.distributed_type = DistributedType.MULTI_CPU
+        self.sync_gradients = True
+
+    def reduce(self, value, reduction):
+        assert reduction == "sum"
+        reduced = value.clone()
+        dist.all_reduce(reduced, op=dist.ReduceOp.SUM)
+        return reduced
+
+    def no_sync(self, model):
+        return model.no_sync()
+
+    def backward(self, loss):
+        (loss / self.gradient_accumulation_steps).backward()
+
+
+def _direct_model():
+    model = nn.Linear(2, 2, bias=True)
+    with torch.no_grad():
+        model.weight.copy_(torch.tensor([[0.25, -0.5], [0.4, 0.1]], dtype=torch.float32))
+        model.bias.copy_(torch.tensor([0.125, -0.2], dtype=torch.float32))
+    return model
+
+
+def _direct_batch(rank, index, selected):
+    seq_len = max(selected + 1, 2)
+    raw = torch.arange(seq_len * 2, dtype=torch.float32).reshape(seq_len, 2)
+    x = (raw + rank * 3 + index) / 7
+    target = torch.stack((0.3 * x[:, 0] - 0.2, -0.4 * x[:, 1] + 0.1), dim=-1)
+    mask = torch.zeros((1, seq_len), dtype=torch.bool)
+    mask[0, :selected] = True
+    return {
+        "mel": x.transpose(0, 1).unsqueeze(0),
+        "mel_lengths": torch.tensor([seq_len]),
+        "target": target,
+        "text": ["test"],
+    }, mask
+
+
+def _run_direct_ddp_case(rank, world_size, *, gradient_accumulation_steps, rank_counts):
+    pairs = [_direct_batch(rank, index, selected) for index, selected in enumerate(rank_counts[rank])]
+    batches = [pair[0] for pair in pairs]
+    masks = [pair[1] for pair in pairs]
+    model = _direct_model()
+    ddp_model = DistributedDataParallel(model)
+    optimizer = torch.optim.SGD(ddp_model.parameters(), lr=0.03, momentum=0.8)
+    trainer = Trainer.__new__(Trainer)
+    trainer.grad_accumulation_steps = gradient_accumulation_steps
+    trainer.accelerator = _DirectDDPAccelerator(
+        world_size=world_size,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+    )
+    trainer.model = ddp_model
+    trainer._unwrapped_model = _MaskSampler(masks)
+
+    boundaries = []
+    for batch, mask, loss_scale, _, is_boundary in trainer._iter_global_masked_mean_batches(batches):
+        boundaries.append(is_boundary)
+        with trainer._accumulation_context(is_boundary):
+            x = batch["mel"].permute(0, 2, 1).squeeze(0)
+            residual = ddp_model(x) - batch["target"]
+            loss_sum = (residual.square() * mask.squeeze(0)[:, None]).sum()
+            trainer.accelerator.backward(loss_sum * loss_scale)
+            if trainer.accelerator.sync_gradients:
+                optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+    assert boundaries[-1] is True
+
+    reference = _direct_model()
+    reference_optimizer = torch.optim.SGD(reference.parameters(), lr=0.03, momentum=0.8)
+    global_loss_sum = torch.zeros((), dtype=torch.float32)
+    global_denominator = 0
+    for peer_rank, counts in enumerate(rank_counts):
+        for index, selected in enumerate(counts):
+            batch, mask = _direct_batch(peer_rank, index, selected)
+            x = batch["mel"].permute(0, 2, 1).squeeze(0)
+            residual = reference(x) - batch["target"]
+            global_loss_sum = global_loss_sum + (residual.square() * mask.squeeze(0)[:, None]).sum()
+            global_denominator += selected * 2
+    (global_loss_sum / global_denominator).backward()
+    reference_optimizer.step()
+
+    torch.testing.assert_close(model.weight, reference.weight, atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(model.bias, reference.bias, atol=1e-6, rtol=1e-6)
+
+
+def _direct_ddp_worker(rank, world_size, init_method):
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+        timeout=datetime.timedelta(seconds=30),
+    )
+    try:
+        _run_direct_ddp_case(
+            rank,
+            world_size,
+            gradient_accumulation_steps=2,
+            rank_counts=((1, 0), (4, 2)),
+        )
+        dist.barrier()
+        _run_direct_ddp_case(
+            rank,
+            world_size,
+            gradient_accumulation_steps=4,
+            rank_counts=((0, 0), (5, 1)),
+        )
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="gloo backend unavailable")
+def test_production_helpers_match_global_batch_on_two_rank_gloo():
+    with tempfile.TemporaryDirectory(prefix="f5-global-contract-gloo-") as tmpdir:
+        mp.start_processes(
+            _direct_ddp_worker,
+            args=(2, f"file://{tmpdir}/store"),
+            nprocs=2,
+            join=True,
+            start_method="fork",
+        )

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -241,9 +241,10 @@ def test_forward_rejects_non_boolean_presampled_mask(bad_mask):
 
 
 class _MaskSampler:
-    def __init__(self, masks):
+    def __init__(self, masks, *, vocab_char_map=None):
         self.masks = iter(masks)
         self.calls = []
+        self.vocab_char_map = vocab_char_map
 
     def sample_training_mask(self, lens, seq_len):
         self.calls.append((lens.clone(), seq_len))
@@ -276,14 +277,21 @@ def _batch(*, mel_channels=2, seq_len=5):
     }
 
 
-def _iterator_trainer(masks, *, gradient_accumulation_steps=3, num_processes=1, remote_denominator=0):
+def _iterator_trainer(
+    masks,
+    *,
+    gradient_accumulation_steps=3,
+    num_processes=1,
+    remote_denominator=0,
+    vocab_char_map=None,
+):
     trainer = Trainer.__new__(Trainer)
     trainer.grad_accumulation_steps = gradient_accumulation_steps
     trainer.accelerator = _IteratorAccelerator(
         num_processes=num_processes,
         remote_denominator=remote_denominator,
     )
-    trainer._unwrapped_model = _MaskSampler(masks)
+    trainer._unwrapped_model = _MaskSampler(masks, vocab_char_map=vocab_char_map)
     return trainer
 
 
@@ -310,7 +318,11 @@ def test_window_iterator_uses_int64_denominator_tensor_and_exact_boundaries():
 
 def test_window_iterator_accepts_preprocessed_pinyin_token_lists():
     mask = torch.tensor([[True, True, False]])
-    trainer = _iterator_trainer([mask], gradient_accumulation_steps=1)
+    trainer = _iterator_trainer(
+        [mask],
+        gradient_accumulation_steps=1,
+        vocab_char_map={" ": 0, "ni3": 1, "hao3": 2},
+    )
     batch = _batch(mel_channels=2, seq_len=3)
     batch["text"] = [[" ", "ni3", "hao3"]]
 
@@ -319,6 +331,15 @@ def test_window_iterator_accepts_preprocessed_pinyin_token_lists():
     assert yielded[0] is batch
     assert yielded[1] is mask
     assert yielded[4] is True
+
+
+def test_window_iterator_rejects_nested_tokens_without_vocabulary_map():
+    trainer = _iterator_trainer([torch.ones((1, 3), dtype=torch.bool)], gradient_accumulation_steps=1)
+    batch = _batch(mel_channels=2, seq_len=3)
+    batch["text"] = [[" ", "ni3", "hao3"]]
+
+    with pytest.raises(ValueError, match="nested text token lists require a vocabulary map"):
+        list(trainer._iter_global_masked_mean_batches([batch]))
 
 
 def test_window_iterator_rejects_non_string_preprocessed_text_tokens():
@@ -759,6 +780,60 @@ def _malformed_ddp_worker(rank, world_size, init_method):
         dist.barrier()
     finally:
         dist.destroy_process_group()
+
+
+def _rank_oom_worker(rank, world_size, init_method):
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+        timeout=datetime.timedelta(seconds=30),
+    )
+    try:
+        class _RankMaskSampler:
+            num_channels = 2
+            vocab_char_map = None
+
+            def sample_training_mask(self, lens, seq_len):
+                if rank == 0:
+                    oom_type = getattr(torch.cuda, "OutOfMemoryError", RuntimeError)
+                    raise oom_type("CUDA out of memory. synthetic rank failure")
+                return torch.ones((lens.shape[0], seq_len), dtype=torch.bool)
+
+        batch, _ = _direct_batch(rank, 0, selected=2)
+        trainer = Trainer.__new__(Trainer)
+        trainer.grad_accumulation_steps = 1
+        trainer.accelerator = _DirectDDPAccelerator(world_size=world_size, gradient_accumulation_steps=1)
+        trainer._unwrapped_model = _RankMaskSampler()
+        try:
+            list(trainer._iter_global_masked_mean_batches([batch]))
+        except BaseException as exc:
+            status = (type(exc).__name__, str(exc))
+        else:  # pragma: no cover - a missing collective error would land here
+            status = ("no-error", "")
+
+        statuses = [None] * world_size
+        dist.all_gather_object(statuses, status)
+        assert all(status[1] for status in statuses)
+        assert "out of memory" in statuses[0][1].lower()
+        assert "another rank" in statuses[1][1].lower()
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="gloo backend unavailable")
+def test_rank_local_cuda_oom_is_preserved_without_peer_hang():
+    with tempfile.TemporaryDirectory(prefix="f5-global-oom-gloo-") as tmpdir:
+        mp.start_processes(
+            _rank_oom_worker,
+            args=(2, f"file://{tmpdir}/store"),
+            nprocs=2,
+            join=True,
+            start_method="spawn",
+        )
 
 
 @pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="gloo backend unavailable")

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -152,6 +152,56 @@ def test_presampled_mask_matches_with_production_compile_entrypoint():
     torch.testing.assert_close(compiled.transformer.gain.grad, eager.transformer.gain.grad)
 
 
+def test_runtime_compile_failure_reports_permanent_eager_fallback(monkeypatch):
+    from torch._dynamo.exc import Unsupported
+
+    def fake_compile(function, **kwargs):
+        del function, kwargs
+
+        def fail_compiled_call(*args):
+            del args
+            raise Unsupported("forced runtime compiler failure")
+
+        return fail_compiled_call
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    model = _tiny_cfm()
+    model.compile_training_core(runtime_fallback=True)
+    x1 = torch.arange(16, dtype=torch.float32).reshape(2, 4, 2) / 8
+    text = torch.tensor([[1, 2], [3, 4]])
+    mask = torch.tensor([[True, True, True, True], [True, True, True, False]])
+    rand_span_mask = torch.tensor([[True, False, True, False], [False, True, True, False]])
+    x0 = torch.zeros_like(x1)
+    time = torch.tensor([0.25, 0.75])
+
+    loss, loss_sum, denominator, _, _ = model._run_loss_core_components(
+        x1,
+        text,
+        mask,
+        rand_span_mask,
+        x0,
+        time,
+        False,
+        False,
+    )
+
+    assert torch.isfinite(loss)
+    assert torch.isfinite(loss_sum)
+    assert denominator > 0
+    assert model.training_compile_state["enabled"] is False
+    assert model.training_compile_state["fallback_active"] is True
+    assert "forced runtime compiler failure" in model.training_compile_state["error"]
+
+    trainer = Trainer.__new__(Trainer)
+    trainer._unwrapped_model = model
+    trainer.accelerator = SimpleNamespace(is_main_process=False)
+    trainer.compile_active = True
+    trainer.compile_fallback_active = False
+    trainer._check_compile_runtime_fallback()
+    assert trainer.compile_active is False
+    assert trainer.compile_fallback_active is True
+
+
 def test_forward_rejects_presampled_mask_with_wrong_shape():
     model = _tiny_cfm()
     inp = torch.zeros((2, 4, 2))

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -7,6 +7,9 @@ import random
 import tempfile
 from types import SimpleNamespace
 
+# Multiprocessing "spawn" imports this module outside pytest's normal conftest
+# loading path. Import the lightweight optional-dependency stubs before F5-TTS.
+import conftest  # noqa: F401
 import pytest
 import torch
 import torch.distributed as dist
@@ -416,10 +419,14 @@ class _DeepSpeedPluginStub:
     def __init__(self, *, zero_stage=0, gradient_clipping=1.0):
         self.zero_stage = zero_stage
         self.gradient_clipping = gradient_clipping
+        self.deepspeed_config = {
+            "gradient_accumulation_steps": "auto",
+            "gradient_clipping": gradient_clipping,
+        }
 
     def get_value(self, key):
-        assert key == "gradient_clipping"
-        return self.gradient_clipping
+        assert key in {"gradient_accumulation_steps", "gradient_clipping"}
+        return self.deepspeed_config[key]
 
 
 class _BackendAccelerator:
@@ -463,7 +470,7 @@ def test_deepspeed_backend_validation_rejects_sharded_zero_until_checkpoint_and_
     trainer = _backend_trainer(zero_stage=zero_stage)
 
     with pytest.raises(NotImplementedError, match="ZeRO stage 0 only"):
-        trainer._validate_global_masked_mean_backend()
+        trainer._validate_global_masked_mean_config()
 
 
 def test_deepspeed_backend_validation_rejects_nonworld_data_parallel_group():
@@ -665,5 +672,5 @@ def test_production_helpers_match_global_batch_on_two_rank_gloo():
             args=(2, f"file://{tmpdir}/store"),
             nprocs=2,
             join=True,
-            start_method="fork",
+            start_method="spawn",
         )

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -792,6 +792,7 @@ def _rank_oom_worker(rank, world_size, init_method):
         timeout=datetime.timedelta(seconds=30),
     )
     try:
+
         class _RankMaskSampler:
             num_channels = 2
             vocab_char_map = None

--- a/tests/test_global_masked_mean_contract.py
+++ b/tests/test_global_masked_mean_contract.py
@@ -686,11 +686,48 @@ def _direct_ddp_worker(rank, world_size, init_method):
         dist.destroy_process_group()
 
 
+def _malformed_ddp_worker(rank, world_size, init_method):
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+        timeout=datetime.timedelta(seconds=30),
+    )
+    try:
+        batch, mask = _direct_batch(rank, 0, selected=2)
+        if rank == 0:
+            batch["mel_lengths"] = batch["mel_lengths"].to(dtype=torch.float32)
+        trainer = Trainer.__new__(Trainer)
+        trainer.grad_accumulation_steps = 1
+        trainer.accelerator = _DirectDDPAccelerator(world_size=world_size, gradient_accumulation_steps=1)
+        trainer._unwrapped_model = _MaskSampler([mask])
+
+        with pytest.raises(ValueError, match="global_masked_mean rejected an accumulation window"):
+            list(trainer._iter_global_masked_mean_batches([batch]))
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
 @pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="gloo backend unavailable")
 def test_production_helpers_match_global_batch_on_two_rank_gloo():
     with tempfile.TemporaryDirectory(prefix="f5-global-contract-gloo-") as tmpdir:
         mp.start_processes(
             _direct_ddp_worker,
+            args=(2, f"file://{tmpdir}/store"),
+            nprocs=2,
+            join=True,
+            start_method="spawn",
+        )
+
+
+@pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="gloo backend unavailable")
+def test_rank_local_malformed_batch_raises_collectively_before_backward():
+    with tempfile.TemporaryDirectory(prefix="f5-global-malformed-gloo-") as tmpdir:
+        mp.start_processes(
+            _malformed_ddp_worker,
             args=(2, f"file://{tmpdir}/store"),
             nprocs=2,
             join=True,

--- a/tests/test_global_masked_mean_cuda.py
+++ b/tests/test_global_masked_mean_cuda.py
@@ -1,0 +1,341 @@
+"""Single-GPU CUDA validation for global masked-mean training.
+
+These tests are skipped on non-CUDA hosts. They deliberately use the real
+Trainer window/scaling helpers and CFM compile entrypoint while keeping the
+model tiny enough for a developer RTX-class GPU.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+import torch
+from accelerate.utils import DistributedType, send_to_device
+from torch import nn
+
+from f5_tts.model.cfm import CFM
+from f5_tts.model.trainer import Trainer
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")
+
+
+class _CudaAccelerator:
+    def __init__(self, *, gradient_accumulation_steps):
+        self.device = torch.device("cuda", 0)
+        self.num_processes = 1
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.distributed_type = DistributedType.NO
+        self.sync_gradients = True
+        self.reduced_dtypes = []
+
+    def reduce(self, value, reduction):
+        assert reduction == "sum"
+        self.reduced_dtypes.append(value.dtype)
+        return value
+
+    def no_sync(self, model):
+        return contextlib.nullcontext()
+
+    def backward(self, loss):
+        (loss / self.gradient_accumulation_steps).backward()
+
+
+class _FixedCudaMaskSampler:
+    def __init__(self, masks, *, num_channels):
+        self.masks = iter(masks)
+        self.num_channels = num_channels
+        self.returned = []
+
+    def sample_training_mask(self, lens, seq_len):
+        mask = next(self.masks).to(device="cuda")
+        assert mask.shape == (lens.shape[0], seq_len)
+        self.returned.append(mask)
+        return mask
+
+
+def _linear_model(channels):
+    model = nn.Linear(channels, channels, bias=True, device="cuda")
+    with torch.no_grad():
+        values = torch.arange(channels * channels, device="cuda", dtype=torch.float32).reshape(channels, channels)
+        model.weight.copy_((values - values.mean()) / (channels * 3))
+        model.bias.copy_(torch.linspace(-0.1, 0.1, channels, device="cuda"))
+    return model
+
+
+def _cuda_batches(mask_counts, *, channels):
+    batches = []
+    masks = []
+    for index, count in enumerate(mask_counts):
+        seq_len = max(count + 2, 3)
+        raw = torch.arange(seq_len * channels, dtype=torch.float32).reshape(seq_len, channels)
+        x = ((raw + index * 3) % 17 - 8) / 7
+        target = 0.25 * x.flip(-1) - 0.13 * x + (index + 1) * 0.03
+        mask = torch.zeros((1, seq_len), dtype=torch.bool)
+        mask[0, :count] = True
+        batches.append(
+            {
+                "mel": x.transpose(0, 1).unsqueeze(0),
+                "mel_lengths": torch.tensor([seq_len]),
+                "target": target.unsqueeze(0),
+                "text": ["cuda"],
+            }
+        )
+        masks.append(mask)
+    return batches, masks
+
+
+def _cuda_candidate_and_reference(mask_counts, *, gradient_accumulation_steps, autocast_dtype=None):
+    channels = 4
+    batches, masks = _cuda_batches(mask_counts, channels=channels)
+    candidate = _linear_model(channels)
+    reference = _linear_model(channels)
+    reference.load_state_dict(candidate.state_dict())
+    candidate_optimizer = torch.optim.SGD(candidate.parameters(), lr=0.03, momentum=0.8)
+    reference_optimizer = torch.optim.SGD(reference.parameters(), lr=0.03, momentum=0.8)
+    accelerator = _CudaAccelerator(gradient_accumulation_steps=gradient_accumulation_steps)
+    sampler = _FixedCudaMaskSampler(masks, num_channels=channels)
+    trainer = Trainer.__new__(Trainer)
+    trainer.grad_accumulation_steps = gradient_accumulation_steps
+    trainer.accelerator = accelerator
+    trainer.model = candidate
+    trainer._unwrapped_model = sampler
+    optimizer_steps = 0
+    yielded_denominators = []
+    yielded_masks = []
+
+    autocast = (
+        torch.autocast(device_type="cuda", dtype=autocast_dtype)
+        if autocast_dtype is not None
+        else contextlib.nullcontext()
+    )
+    for batch, mask, loss_scale, denominator, is_boundary in trainer._iter_global_masked_mean_batches(batches):
+        # The final production iterator yields host batches; tolerate the
+        # pre-fix GPU-yielding form so this test also diagnoses its residency.
+        if batch["mel"].device.type != "cuda":
+            batch = send_to_device(batch, accelerator.device)
+        yielded_denominators.append(denominator)
+        yielded_masks.append(mask.detach().cpu())
+        with trainer._accumulation_context(is_boundary), autocast:
+            x = batch["mel"].permute(0, 2, 1)
+            prediction = candidate(x)
+            residual = prediction.float() - batch["target"].float()
+            loss_sum = (residual.square() * mask[..., None]).sum()
+            accelerator.backward(loss_sum * loss_scale)
+            if accelerator.sync_gradients:
+                candidate_optimizer.step()
+                candidate_optimizer.zero_grad(set_to_none=True)
+                optimizer_steps += 1
+
+    reference_loss_sum = torch.zeros((), device="cuda", dtype=torch.float32)
+    denominator_value = 0
+    with autocast:
+        for batch, mask in zip(batches, masks):
+            batch = send_to_device(batch, accelerator.device)
+            prediction = reference(batch["mel"].permute(0, 2, 1))
+            residual = prediction.float() - batch["target"].float()
+            reference_loss_sum = reference_loss_sum + (residual.square() * mask.to(device="cuda")[..., None]).sum()
+            denominator_value += int(mask.sum()) * channels
+    (reference_loss_sum / denominator_value).backward()
+    reference_optimizer.step()
+    torch.cuda.synchronize()
+
+    return {
+        "candidate": candidate,
+        "reference": reference,
+        "optimizer_steps": optimizer_steps,
+        "denominators": yielded_denominators,
+        "yielded_masks": yielded_masks,
+        "input_masks": masks,
+        "reduced_dtypes": accelerator.reduced_dtypes,
+    }
+
+
+@pytest.mark.parametrize(
+    "mask_counts,gradient_accumulation_steps",
+    [
+        ([1, 7, 2], 3),
+        ([0, 5], 4),
+    ],
+    ids=["full-window", "partial-window"],
+)
+def test_cuda_fp32_full_and_partial_updates_match_global_reference(mask_counts, gradient_accumulation_steps):
+    result = _cuda_candidate_and_reference(
+        mask_counts,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+    )
+
+    torch.testing.assert_close(result["candidate"].weight, result["reference"].weight, atol=2e-6, rtol=2e-6)
+    torch.testing.assert_close(result["candidate"].bias, result["reference"].bias, atol=2e-6, rtol=2e-6)
+    assert result["optimizer_steps"] == 1
+    assert all(
+        denominator.dtype == torch.int64 and denominator.device.type == "cuda" for denominator in result["denominators"]
+    )
+    assert result["reduced_dtypes"] == [torch.int64]
+    for yielded, expected in zip(result["yielded_masks"], result["input_masks"]):
+        assert torch.equal(yielded, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_bf16_supported(), reason="CUDA BF16 unavailable")
+@pytest.mark.parametrize(
+    "mask_counts,gradient_accumulation_steps",
+    [
+        ([1, 7, 2], 3),
+        ([0, 5], 4),
+    ],
+    ids=["full-window", "partial-window"],
+)
+def test_cuda_bf16_full_and_partial_updates_match_global_reference(mask_counts, gradient_accumulation_steps):
+    result = _cuda_candidate_and_reference(
+        mask_counts,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+        autocast_dtype=torch.bfloat16,
+    )
+
+    torch.testing.assert_close(result["candidate"].weight, result["reference"].weight, atol=3e-5, rtol=3e-5)
+    torch.testing.assert_close(result["candidate"].bias, result["reference"].bias, atol=3e-5, rtol=3e-5)
+    assert result["optimizer_steps"] == 1
+
+
+class _DummyMelSpec(nn.Module):
+    n_mel_channels = 2
+    target_sample_rate = 24_000
+    hop_length = 256
+
+    def forward(self, wav):  # pragma: no cover - validation passes mel tensors
+        raise AssertionError("audio frontend must not run")
+
+
+class _CompiledTinyTransformer(nn.Module):
+    dim = 2
+
+    def __init__(self):
+        super().__init__()
+        self.projection = nn.Linear(2, 2)
+
+    def forward(self, *, x, **kwargs):
+        return self.projection(x)
+
+
+def _compiled_cfm():
+    return CFM(
+        _CompiledTinyTransformer(),
+        num_channels=2,
+        mel_spec_module=_DummyMelSpec(),
+        audio_drop_prob=0,
+        cond_drop_prob=0,
+    ).cuda()
+
+
+def _fixed_core_args(seed, mask):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    batch, seq_len = mask.shape
+    x1 = torch.randn((batch, seq_len, 2), device="cuda", generator=generator)
+    text = torch.zeros((batch, 2), device="cuda", dtype=torch.long)
+    valid_mask = torch.ones((batch, seq_len), device="cuda", dtype=torch.bool)
+    x0 = torch.randn(x1.shape, device="cuda", generator=generator)
+    time = torch.rand((batch,), device="cuda", generator=generator)
+    return x1, text, valid_mask, mask, x0, time, False, False
+
+
+@pytest.mark.skipif(not hasattr(torch, "compile"), reason="torch.compile unavailable")
+def test_cuda_inductor_compiled_core_uses_production_window_scale_before_backward():
+    masks = [
+        torch.tensor([[True, False, True, False, False, False]], device="cuda"),
+        torch.tensor([[False, True, True, True, False, False]], device="cuda"),
+    ]
+    compiled = _compiled_cfm()
+    eager = _compiled_cfm()
+    eager.load_state_dict(compiled.state_dict())
+    compiled.compile_training_core(
+        backend="inductor",
+        fullgraph=True,
+        dynamic=True,
+        runtime_fallback=False,
+    )
+    compiled_optimizer = torch.optim.SGD(compiled.parameters(), lr=0.02)
+    eager_optimizer = torch.optim.SGD(eager.parameters(), lr=0.02)
+    accelerator = _CudaAccelerator(gradient_accumulation_steps=2)
+    trainer = Trainer.__new__(Trainer)
+    trainer.grad_accumulation_steps = 2
+    trainer.accelerator = accelerator
+    trainer.model = compiled
+    trainer._unwrapped_model = _FixedCudaMaskSampler(
+        [mask.cpu() for mask in masks],
+        num_channels=2,
+    )
+    host_batches = [
+        {
+            "mel": torch.zeros((1, 2, 6)),
+            "mel_lengths": torch.tensor([6]),
+            "text": ["compile"],
+        }
+        for _ in masks
+    ]
+    entries = list(trainer._iter_global_masked_mean_batches(host_batches))
+    denominator = int(sum(int(mask.sum()) * 2 for mask in masks))
+    eager_total = torch.zeros((), device="cuda")
+
+    for index, (_, yielded_mask, loss_scale, yielded_denominator, is_boundary) in enumerate(entries):
+        args = _fixed_core_args(500 + index, yielded_mask)
+        _, compiled_sum, _, _, _ = compiled._run_loss_core_components(*args)
+        with trainer._accumulation_context(is_boundary):
+            accelerator.backward(compiled_sum * loss_scale)
+            if accelerator.sync_gradients:
+                compiled_optimizer.step()
+        _, eager_sum, _, _, _ = eager._forward_loss_core_components(*args)
+        eager_total = eager_total + eager_sum
+        assert yielded_denominator.dtype == torch.int64
+        assert int(yielded_denominator) == denominator
+
+    (eager_total / denominator).backward()
+    eager_optimizer.step()
+    torch.cuda.synchronize()
+
+    for compiled_parameter, eager_parameter in zip(compiled.parameters(), eager.parameters()):
+        torch.testing.assert_close(compiled_parameter, eager_parameter, atol=2e-5, rtol=2e-5)
+    assert compiled.training_compile_state["enabled"] is True
+    assert compiled.training_compile_state["fallback_active"] is False
+
+
+def test_cuda_window_peak_residency_is_bounded_to_one_transferred_mel_batch():
+    channels = 32
+    frames = 300_000
+    accumulation_steps = 3
+    mel_bytes = channels * frames * torch.tensor([], dtype=torch.float32).element_size()
+    host_batches = [
+        {
+            "mel": torch.zeros((1, channels, frames), dtype=torch.float32),
+            "mel_lengths": torch.tensor([frames]),
+            "text": ["memory"],
+        }
+        for _ in range(accumulation_steps)
+    ]
+    masks = [torch.ones((1, frames), dtype=torch.bool) for _ in range(accumulation_steps)]
+    accelerator = _CudaAccelerator(gradient_accumulation_steps=accumulation_steps)
+    trainer = Trainer.__new__(Trainer)
+    trainer.grad_accumulation_steps = accumulation_steps
+    trainer.accelerator = accelerator
+    trainer.model = nn.Identity().cuda()
+    trainer._unwrapped_model = _FixedCudaMaskSampler(masks, num_channels=channels)
+
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    for batch, _, _, _, _ in trainer._iter_global_masked_mean_batches(host_batches):
+        if batch["mel"].device.type != "cuda":
+            batch = send_to_device(batch, accelerator.device)
+        assert batch["mel"].device.type == "cuda"
+    torch.cuda.synchronize()
+    peak_delta = torch.cuda.max_memory_allocated() - baseline
+    print(f"cuda_peak_delta_bytes={peak_delta} mel_batch_bytes={mel_bytes} peak_batches={peak_delta / mel_bytes:.3f}")
+
+    # Masks/scalars add less than 1 MiB. A 25% allowance still rejects the
+    # approximately 2x peak caused by allocating the next device batch while
+    # the caller retains the previous one.
+    assert peak_delta <= int(mel_bytes * 1.25), (
+        f"peak CUDA allocation grew by {peak_delta} bytes for a {mel_bytes}-byte mel batch; "
+        "more than one transferred batch was simultaneously resident"
+    )

--- a/tests/test_global_masked_mean_overflow_resume.py
+++ b/tests/test_global_masked_mean_overflow_resume.py
@@ -1,0 +1,180 @@
+"""Focused regression for overflow accounting and resume position."""
+
+from __future__ import annotations
+
+import contextlib
+
+import torch
+from accelerate.utils import DistributedType
+from torch import nn
+
+import f5_tts.model.trainer as trainer_module
+from f5_tts.model.trainer import Trainer
+
+
+class _OneBatchLoader:
+    def __init__(self):
+        self.batch_sampler = object()
+        self.batch = {
+            "mel": torch.ones((1, 2, 3)),
+            "mel_lengths": torch.tensor([3]),
+            "text": ["overflow"],
+        }
+
+    def __len__(self):
+        return 1
+
+    def __iter__(self):
+        yield self.batch
+
+
+class _OverflowModel(nn.Module):
+    num_channels = 2
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor(0.5))
+        self.forward_calls = 0
+
+    def sample_training_mask(self, lens, seq_len):
+        return torch.ones((lens.shape[0], seq_len), dtype=torch.bool)
+
+    def forward(
+        self,
+        mel,
+        *,
+        text,
+        lens,
+        noise_scheduler,
+        rand_span_mask,
+        return_loss_components,
+    ):
+        del text, lens, noise_scheduler
+        assert return_loss_components is True
+        self.forward_calls += 1
+        denominator = rand_span_mask.sum(dtype=torch.float32) * mel.shape[-1]
+        loss_sum = self.weight.square() * denominator
+        loss = loss_sum / denominator
+        return loss, loss_sum, denominator, mel, mel
+
+
+class _SkippingSGD(torch.optim.SGD):
+    """Simulate GradScaler detecting overflow and suppressing optimizer.step."""
+
+    def __init__(self, params):
+        super().__init__(params, lr=0.01)
+        self.attempted_steps = 0
+
+    def step(self, closure=None):
+        del closure
+        self.attempted_steps += 1
+        return None
+
+
+class _CountingEMA:
+    def __init__(self):
+        self.updates = 0
+
+    def update(self):
+        self.updates += 1
+
+
+class _OverflowAccelerator:
+    def __init__(self, *, optimizer_step_was_skipped):
+        self.device = torch.device("cpu")
+        self.num_processes = 1
+        self.distributed_type = DistributedType.NO
+        self.dispatch_batches = False
+        self.sync_gradients = True
+        self.optimizer_step_was_skipped = optimizer_step_was_skipped
+        self.is_main_process = True
+        self.is_local_main_process = True
+        self.skip_calls = []
+        self.end_calls = 0
+
+    def prepare_data_loader(self, dataloader, device_placement):
+        assert device_placement is False
+        return dataloader
+
+    def prepare(self, value):
+        return value
+
+    def gather(self, value):
+        return value
+
+    def reduce(self, value, reduction):
+        assert reduction == "sum"
+        return value
+
+    def no_sync(self, model):
+        return contextlib.nullcontext()
+
+    def backward(self, loss):
+        loss.backward()
+
+    def skip_first_batches(self, dataloader, num_batches):
+        self.skip_calls.append(num_batches)
+        if num_batches == 0:
+            return dataloader
+        return list(dataloader)[num_batches:]
+
+    def log(self, *args, **kwargs):
+        return None
+
+    def end_training(self):
+        self.end_calls += 1
+
+
+def _trainer(*, overflow, checkpoint_cursor):
+    model = _OverflowModel()
+    trainer = Trainer.__new__(Trainer)
+    trainer.model = model
+    trainer._unwrapped_model = model
+    trainer.optimizer = _SkippingSGD(model.parameters())
+    trainer.ema_model = _CountingEMA()
+    trainer.accelerator = _OverflowAccelerator(optimizer_step_was_skipped=overflow)
+    trainer.global_masked_mean = True
+    trainer.grad_accumulation_steps = 1
+    trainer.max_grad_norm = 0
+    trainer.log_samples = False
+    trainer.batch_size_type = "sample"
+    trainer.batch_size_per_gpu = 1
+    trainer.max_samples = 1
+    trainer.num_warmup_updates = 0
+    trainer.epochs = 1
+    trainer.duration_predictor = None
+    trainer.noise_scheduler = None
+    trainer.compile_active = False
+    trainer.logger = None
+    trainer.last_per_updates = 100
+    trainer.save_per_updates = 100
+    trainer.saved = []
+    trainer.load_checkpoint = lambda: checkpoint_cursor
+    trainer.save_checkpoint = lambda update, consumed_updates, last=False: trainer.saved.append(
+        (update, consumed_updates, last)
+    )
+    return trainer
+
+
+def test_overflow_consumes_window_without_advancing_update_or_ema_and_resume_skips_it(monkeypatch):
+    monkeypatch.setattr(trainer_module, "DataLoader", lambda *args, **kwargs: _OneBatchLoader())
+    overflowed = _trainer(overflow=True, checkpoint_cursor=(0, 0))
+
+    overflowed.train(object(), num_workers=0)
+
+    assert overflowed.optimizer.attempted_steps == 1
+    assert overflowed.ema_model.updates == 0
+    assert overflowed.model.forward_calls == 1
+    assert overflowed.saved[-1] == (0, 1, True)
+
+    # A restart has zero successful optimizer updates but one consumed
+    # accumulation window. The consumed cursor must skip the completed epoch;
+    # using global_update=0 would replay the overflowed batch.
+    resumed = _trainer(overflow=False, checkpoint_cursor=(0, 1))
+    resumed.train(object(), num_workers=0, resumable_with_seed=123)
+
+    assert resumed.accelerator.skip_calls == [0]
+    assert resumed.model.forward_calls == 0
+    assert resumed.optimizer.attempted_steps == 0
+    assert resumed.ema_model.updates == 0
+    assert resumed.saved[-1] == (0, 1, True)

--- a/tests/test_global_masked_mean_overflow_resume.py
+++ b/tests/test_global_masked_mean_overflow_resume.py
@@ -46,16 +46,19 @@ class _OverflowModel(nn.Module):
         text,
         lens,
         noise_scheduler,
-        rand_span_mask,
-        return_loss_components,
+        rand_span_mask=None,
+        return_loss_components=False,
     ):
         del text, lens, noise_scheduler
-        assert return_loss_components is True
         self.forward_calls += 1
+        if rand_span_mask is None:
+            rand_span_mask = torch.ones(mel.shape[0], mel.shape[-1], dtype=torch.bool)
         denominator = rand_span_mask.sum(dtype=torch.float32) * mel.shape[-1]
         loss_sum = self.weight.square() * denominator
         loss = loss_sum / denominator
-        return loss, loss_sum, denominator, mel, mel
+        if return_loss_components:
+            return loss, loss_sum, denominator, mel, mel
+        return loss, mel, mel
 
 
 class _ControlledSGD(torch.optim.SGD):
@@ -101,8 +104,8 @@ class _OverflowAccelerator:
         assert device_placement is False
         return dataloader
 
-    def prepare(self, value):
-        return value
+    def prepare(self, *objects):
+        return objects if len(objects) > 1 else objects[0]
 
     def gather(self, value):
         return value
@@ -110,6 +113,10 @@ class _OverflowAccelerator:
     def reduce(self, value, reduction):
         assert reduction == "sum"
         return value
+
+    def accumulate(self, model):
+        del model
+        return contextlib.nullcontext()
 
     def no_sync(self, model):
         return contextlib.nullcontext()
@@ -130,7 +137,7 @@ class _OverflowAccelerator:
         self.end_calls += 1
 
 
-def _trainer(*, overflow, checkpoint_cursor):
+def _trainer(*, overflow, checkpoint_cursor, global_masked_mean=True):
     model = _OverflowModel()
     trainer = Trainer.__new__(Trainer)
     trainer.model = model
@@ -138,7 +145,7 @@ def _trainer(*, overflow, checkpoint_cursor):
     trainer.optimizer = _ControlledSGD(model.parameters(), skip_update=overflow)
     trainer.ema_model = _CountingEMA()
     trainer.accelerator = _OverflowAccelerator(optimizer_step_was_skipped=overflow)
-    trainer.global_masked_mean = True
+    trainer.global_masked_mean = global_masked_mean
     trainer.grad_accumulation_steps = 1
     trainer.max_grad_norm = 0
     trainer.log_samples = False
@@ -154,7 +161,7 @@ def _trainer(*, overflow, checkpoint_cursor):
     trainer.last_per_updates = 100
     trainer.save_per_updates = 100
     trainer.saved = []
-    trainer.load_checkpoint = lambda: checkpoint_cursor
+    trainer.load_checkpoint = lambda *args, **kwargs: checkpoint_cursor
     trainer.save_checkpoint = lambda update, consumed_updates, last=False: trainer.saved.append(
         (update, consumed_updates, last)
     )
@@ -198,3 +205,14 @@ def test_overflow_consumes_window_without_advancing_update_or_ema_and_resume_ski
     assert resumed.optimizer.attempted_steps == 0
     assert resumed.ema_model.updates == 0
     assert resumed.saved[-1] == (0, 1, True)
+
+
+def test_non_global_masked_mean_overflow_does_not_advance_update_or_ema(monkeypatch):
+    monkeypatch.setattr(trainer_module, "DataLoader", lambda *args, **kwargs: _OneBatchLoader())
+    overflowed = _trainer(overflow=True, checkpoint_cursor=(0, 0), global_masked_mean=False)
+
+    overflowed.train(object(), num_workers=0)
+
+    assert overflowed.optimizer.attempted_steps == 1
+    assert overflowed.ema_model.updates == 0
+    assert overflowed.saved[-1] == (0, 1, True)

--- a/tests/test_global_masked_mean_overflow_resume.py
+++ b/tests/test_global_masked_mean_overflow_resume.py
@@ -58,17 +58,22 @@ class _OverflowModel(nn.Module):
         return loss, loss_sum, denominator, mel, mel
 
 
-class _SkippingSGD(torch.optim.SGD):
-    """Simulate GradScaler detecting overflow and suppressing optimizer.step."""
+class _ControlledSGD(torch.optim.SGD):
+    """Capture the production gradient and optionally simulate an AMP skip."""
 
-    def __init__(self, params):
+    def __init__(self, params, *, skip_update):
         super().__init__(params, lr=0.01)
+        self.skip_update = skip_update
         self.attempted_steps = 0
+        self.last_gradient = None
 
     def step(self, closure=None):
-        del closure
         self.attempted_steps += 1
-        return None
+        [parameter] = self.param_groups[0]["params"]
+        self.last_gradient = parameter.grad.detach().clone()
+        if self.skip_update:
+            return None
+        return super().step(closure)
 
 
 class _CountingEMA:
@@ -130,7 +135,7 @@ def _trainer(*, overflow, checkpoint_cursor):
     trainer = Trainer.__new__(Trainer)
     trainer.model = model
     trainer._unwrapped_model = model
-    trainer.optimizer = _SkippingSGD(model.parameters())
+    trainer.optimizer = _ControlledSGD(model.parameters(), skip_update=overflow)
     trainer.ema_model = _CountingEMA()
     trainer.accelerator = _OverflowAccelerator(optimizer_step_was_skipped=overflow)
     trainer.global_masked_mean = True
@@ -154,6 +159,21 @@ def _trainer(*, overflow, checkpoint_cursor):
         (update, consumed_updates, last)
     )
     return trainer
+
+
+def test_successful_train_scales_the_production_loss_sum_before_backward(monkeypatch):
+    monkeypatch.setattr(trainer_module, "DataLoader", lambda *args, **kwargs: _OneBatchLoader())
+    trained = _trainer(overflow=False, checkpoint_cursor=(0, 0))
+
+    trained.train(object(), num_workers=0)
+
+    # loss_sum = weight**2 * 6 and the production scale is 1 / 6, so
+    # d(loss_sum * scale) / d(weight) is exactly 2 * 0.5 = 1. A plausible
+    # loss * scale mutation would instead produce 1 / 6.
+    torch.testing.assert_close(trained.optimizer.last_gradient, torch.tensor(1.0))
+    torch.testing.assert_close(trained.model.weight, torch.tensor(0.49))
+    assert trained.ema_model.updates == 1
+    assert trained.saved[-1] == (1, 1, True)
 
 
 def test_overflow_consumes_window_without_advancing_update_or_ema_and_resume_skips_it(monkeypatch):

--- a/tests/test_verified_fixes.py
+++ b/tests/test_verified_fixes.py
@@ -222,9 +222,7 @@ def test_load_checkpoint_restores_cursor_and_rng_state(tmp_path):
     assert target.load_checkpoint(return_cursor=True) == (3, 5)
     assert random.random() == expected_python
     torch.testing.assert_close(torch.rand(()), expected_torch)
-    torch.testing.assert_close(
-        torch.rand((), generator=target._train_dataloader_generator), expected_worker
-    )
+    torch.testing.assert_close(torch.rand((), generator=target._train_dataloader_generator), expected_worker)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_verified_fixes.py
+++ b/tests/test_verified_fixes.py
@@ -1,0 +1,326 @@
+"""Regression tests for verified training, checkpoint, and cache fixes."""
+
+from __future__ import annotations
+
+import copy
+import inspect
+import random
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import conftest  # noqa: F401
+import pytest
+import torch
+from accelerate import Accelerator
+from torch.utils.data import DataLoader
+
+from f5_tts.model.backbones.dit import DiT
+from f5_tts.model.backbones.mmdit import MMDiT
+from f5_tts.model.backbones.unett import UNetT
+from f5_tts.model.cfm import _compile_failure_types
+from f5_tts.model.trainer import Trainer, _EpochRandomSampler
+
+
+CUDA_OOM_TYPE = getattr(torch.cuda, "OutOfMemoryError", RuntimeError)
+
+
+class _PrepareAccelerator:
+    def __init__(self):
+        self.even_batches = True
+        self.dispatch_batches = False
+        self.num_processes = 1
+        self.prepared = []
+
+    def prepare_data_loader(self, dataloader, device_placement):
+        self.prepared.append((dataloader, device_placement))
+        return dataloader
+
+
+class _SizedLoader:
+    def __init__(self, batch_count):
+        self.batch_count = batch_count
+
+    def __len__(self):
+        return self.batch_count
+
+
+class _CheckpointAccelerator:
+    is_main_process = True
+    process_index = 0
+    num_processes = 1
+
+    def wait_for_everyone(self):
+        pass
+
+    def unwrap_model(self, model):
+        return model
+
+    def save(self, state, path):
+        torch.save(state, path)
+
+
+class _IteratorAccelerator:
+    device = torch.device("cpu")
+    num_processes = 1
+
+    def reduce(self, value, reduction):
+        assert reduction == "sum"
+        return value
+
+
+class _OomSampler:
+    num_channels = 2
+    vocab_char_map = None
+
+    def sample_training_mask(self, lens, seq_len):
+        del lens, seq_len
+        oom_type = getattr(torch.cuda, "OutOfMemoryError", RuntimeError)
+        raise oom_type("CUDA out of memory. synthetic")
+
+
+def _batch():
+    return {
+        "mel": torch.zeros((1, 2, 3)),
+        "mel_lengths": torch.tensor([3]),
+        "text": ["test"],
+    }
+
+
+def test_global_masked_mean_preparation_disables_accelerate_duplicate_padding():
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.accelerator = _PrepareAccelerator()
+    validated = []
+    trainer._validate_global_masked_dataloader = lambda loader: validated.append(loader)
+    dataloader = object()
+
+    prepared = trainer._prepare_global_masked_mean_dataloader(dataloader)
+
+    assert prepared is dataloader
+    assert trainer.accelerator.even_batches is False
+    assert validated == [dataloader]
+    assert trainer.accelerator.prepared == [(dataloader, False)]
+
+
+def test_global_masked_mean_rejects_incomplete_process_batch_group():
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.accelerator = _PrepareAccelerator()
+    trainer.accelerator.num_processes = 2
+
+    with pytest.raises(ValueError, match="divisible by the process count"):
+        trainer._prepare_global_masked_mean_dataloader(_SizedLoader(3))
+
+    assert trainer.accelerator.even_batches is False
+    assert trainer.accelerator.prepared == []
+
+
+def test_resumed_sample_loader_sets_epoch_on_dataloader_shard():
+    def make_loader():
+        dataset = list(range(8))
+        sampler = _EpochRandomSampler(dataset, seed=1234)
+        generator = torch.Generator().manual_seed(5678)
+        loader = DataLoader(
+            cast(Any, dataset),
+            batch_size=2,
+            sampler=sampler,
+            shuffle=False,
+            generator=generator,
+        )
+        accelerator = Accelerator(cpu=True)
+        accelerator.even_batches = False
+        return accelerator, accelerator.prepare_data_loader(loader, device_placement=False)
+
+    _, expected_loader = make_loader()
+    Trainer._set_dataloader_epoch(expected_loader, 0)
+    epoch_zero = [tuple(batch.tolist()) for batch in expected_loader]
+    Trainer._set_dataloader_epoch(expected_loader, 1)
+    expected = [tuple(batch.tolist()) for batch in expected_loader]
+    assert expected != epoch_zero
+
+    accelerator, resumed_loader = make_loader()
+    skipped_loader = accelerator.skip_first_batches(resumed_loader, num_batches=0)
+    Trainer._set_dataloader_epoch(skipped_loader, 1)
+    actual = [tuple(batch.tolist()) for batch in skipped_loader]
+
+    assert actual == expected
+
+
+def test_global_masked_mean_preserves_cuda_oom_type_during_mask_preparation():
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.grad_accumulation_steps = 1
+    trainer.accelerator = _IteratorAccelerator()
+    trainer._unwrapped_model = _OomSampler()
+
+    with pytest.raises(CUDA_OOM_TYPE, match="CUDA out of memory"):
+        list(trainer._iter_global_masked_mean_batches([_batch()]))
+
+
+def test_checkpoint_rng_state_round_trip_restores_python_and_torch_rng():
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.accelerator = SimpleNamespace(process_index=0, num_processes=1)
+
+    random.seed(8128)
+    torch.manual_seed(2718)
+    state = trainer._capture_rng_states()
+    expected_python = random.random()
+    expected_torch = torch.rand(())
+
+    trainer._restore_rng_states(state)
+
+    assert random.random() == expected_python
+    torch.testing.assert_close(torch.rand(()), expected_torch)
+
+
+def test_save_checkpoint_preserves_legacy_last_call_and_rng_payload(tmp_path):
+    model = torch.nn.Linear(2, 2)
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.accelerator = _CheckpointAccelerator()
+    trainer.model = model
+    trainer.ema_model = torch.nn.Linear(2, 2)
+    trainer.optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer.scheduler = torch.optim.lr_scheduler.LambdaLR(trainer.optimizer, lambda _: 1.0)
+    trainer.checkpoint_path = str(tmp_path)
+    trainer.keep_last_n_checkpoints = 0
+
+    trainer.save_checkpoint(10, True)
+
+    checkpoint_path = Path(tmp_path) / "model_last.pt"
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    assert checkpoint["update"] == 10
+    assert checkpoint["consumed_updates"] == 10
+    assert len(checkpoint["rng_state"]) == 1
+
+
+def _checkpoint_trainer(checkpoint_path):
+    model = torch.nn.Linear(2, 2)
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.accelerator = _CheckpointAccelerator()
+    trainer.model = model
+    trainer.ema_model = torch.nn.Linear(2, 2)
+    trainer.optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer.scheduler = torch.optim.lr_scheduler.LambdaLR(trainer.optimizer, lambda _: 1.0)
+    trainer.checkpoint_path = str(checkpoint_path)
+    trainer.keep_last_n_checkpoints = 0
+    trainer.grad_accumulation_steps = 1
+    trainer._train_dataloader_generator = torch.Generator().manual_seed(777)
+    return trainer
+
+
+def test_load_checkpoint_restores_cursor_and_rng_state(tmp_path):
+    source = _checkpoint_trainer(tmp_path)
+    target = _checkpoint_trainer(tmp_path)
+    random.seed(101)
+    torch.manual_seed(202)
+
+    source.save_checkpoint(3, 5, True)
+    expected_python = random.random()
+    expected_torch = torch.rand(())
+    expected_worker = torch.rand((), generator=source._train_dataloader_generator)
+
+    random.seed(303)
+    torch.manual_seed(404)
+    assert target.load_checkpoint(return_cursor=True) == (3, 5)
+    assert random.random() == expected_python
+    torch.testing.assert_close(torch.rand(()), expected_torch)
+    torch.testing.assert_close(
+        torch.rand((), generator=target._train_dataloader_generator), expected_worker
+    )
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ((10,), (10, 10, False)),
+        ((10, True), (10, 10, True)),
+        ((10, 7), (10, 7, False)),
+        ((10, 7, True), (10, 7, True)),
+    ],
+)
+def test_checkpoint_arguments_preserve_legacy_and_cursor_forms(args, expected):
+    assert Trainer._normalize_checkpoint_args(*args) == expected
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, True, 1.5])
+def test_invalid_gradient_accumulation_steps_fail_before_accelerator_setup(bad_value):
+    with pytest.raises(ValueError, match="gradient_accumulation_steps must be a positive integer"):
+        Trainer._validate_gradient_accumulation_steps(bad_value)
+
+
+def test_generic_runtime_error_is_not_a_compile_fallback_signal():
+    assert not isinstance(RuntimeError("model failure"), _compile_failure_types())
+
+
+def test_dynamo_wrapped_runtime_error_is_not_a_compile_fallback_signal():
+    dynamo_exc = getattr(torch._dynamo, "exc", None)
+    wrapped_error = getattr(dynamo_exc, "TorchRuntimeError", None) if dynamo_exc is not None else None
+    if wrapped_error is None:
+        pytest.skip("this PyTorch version does not expose TorchRuntimeError")
+    try:
+        error = wrapped_error("model runtime failure")
+    except TypeError:
+        pytest.skip("TorchRuntimeError constructor is not stable on this PyTorch version")
+    assert not isinstance(error, _compile_failure_types())
+
+
+def _small_dit():
+    return DiT(
+        dim=16,
+        depth=2,
+        heads=1,
+        dim_head=4,
+        dropout=0.0,
+        mel_dim=2,
+        text_num_embeds=8,
+        text_dim=4,
+    )
+
+
+def _small_unett():
+    return UNetT(
+        dim=16,
+        depth=2,
+        heads=1,
+        dim_head=4,
+        dropout=0.0,
+        mel_dim=2,
+        text_num_embeds=8,
+        text_dim=4,
+    )
+
+
+def _small_mmdit():
+    return MMDiT(
+        dim=16,
+        depth=1,
+        heads=1,
+        dim_head=4,
+        dropout=0.0,
+        ff_mult=2,
+        mel_dim=2,
+        text_num_embeds=8,
+    )
+
+
+@pytest.mark.parametrize("factory", [_small_dit, _small_mmdit, _small_unett], ids=["dit", "mmdit", "unett"])
+def test_inference_cache_does_not_block_model_deepcopy(factory):
+    model = factory()
+    model.text_cond = torch.ones((1, 2, 16))
+
+    copied = copy.deepcopy(model)
+
+    assert copied.text_cond is None
+
+
+@pytest.mark.parametrize("factory", [_small_dit, _small_mmdit, _small_unett], ids=["dit", "mmdit", "unett"])
+def test_inference_cache_does_not_block_model_pickle(factory, tmp_path):
+    model = factory()
+    model.text_cond = torch.ones((1, 2, 16))
+    path = tmp_path / f"{factory.__name__}.pt"
+
+    torch.save(model, path)
+    load_kwargs: dict[str, Any] = {"map_location": "cpu"}
+    if "weights_only" in inspect.signature(torch.load).parameters:
+        load_kwargs["weights_only"] = False
+    loaded = torch.load(path, **load_kwargs)
+
+    assert loaded.text_cond is None


### PR DESCRIPTION
## Summary

Draft integration branch combining the training changes from the fork stack with the verified hardening fixes. This PR is intentionally opened as a draft for upstream review and does not modify or close the existing fork PRs.

The integration includes:

- opt-in `torch.compile` training targets with runtime fallback boundaries;
- global masked-mean training across distributed accumulation windows;
- safe handling of Accelerate batch padding and incomplete process groups;
- AMP overflow-aware update, scheduler, and EMA accounting;
- deterministic sample-mode resume with epoch-addressable ordering;
- checkpoint cursor and per-process RNG/DataLoader generator restoration;
- CUDA OOM propagation without masking it as input validation failure;
- validation for gradient accumulation and nested tokenized text;
- inference-cache-safe deepcopy/pickle behavior for DiT, MMDiT, and UNetT;
- fused AdamW device gating and zero-worker DataLoader support;
- CPU/Gloo regression coverage and CI workflow.

## Verification

Executed locally with the project environment:

- `PYTHONPATH=src python -m pytest -q`: **98 passed**
- two-rank Gloo production/oracle and rank-local OOM probe: **2 passed**, repeated twice
- `ruff check src tests`: passed
- `python -m compileall -q src`: passed
- `git diff --check`: passed

## GMM data policy

`global_masked_mean=True` disables Accelerate duplicate padding. For non-split multi-process loading, an incomplete process-group batch count is rejected explicitly rather than replaying samples or silently dropping a tail group. A validity-weighted dummy-sample policy can be considered separately if that is preferred contractually.

## Remote CI

After the initial CI run exposed a Torch 2.5 zero-warmup `LinearLR`/`SequentialLR` compatibility issue, the scheduler path was corrected in `70ec57a`. The current remote checks all pass:

- `pre-commit`: passed
- Python 3.10 / Torch 2.0.1 / Accelerate 0.33.0: passed
- Python 3.12 / Torch 2.5.1 / Accelerate 1.14.0: passed

## Known limits for review

- CUDA execution has not been run in this CI workflow.
- Exact RNG reproduction for arbitrary random augmentation inside persistent workers is not guaranteed beyond the restored DataLoader generator state.
- Existing fork PRs #5, #6, #7, #8, and draft #9 remain unchanged; this branch is the consolidated review vehicle.
